### PR TITLE
Only run CI on relevant file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,22 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/ci.yml"
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## summary

add path filters to CI workflow so we don't waste resources running tests/checks on trivial changes like documentation or license file updates.

## changes

CI now only runs when changes are made to:
- `src/**` - source code
- `tests/**` - test files  
- `pyproject.toml` - project config
- `uv.lock` - dependencies
- `.pre-commit-config.yaml` - pre-commit hooks
- `.github/workflows/ci.yml` - CI workflow itself

documentation, license, and readme changes won't trigger CI runs.