### PR TITLE
fix: don't login when reading with --repo flag

### DIFF
--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -175,13 +175,16 @@ async def async_main() -> int:
         # auth required if: doing a write operation OR doing a read without --repo
         auth_needed = not is_read or not has_repo_target
 
-        await login(
-            client,
-            args.handle or settings.atproto_handle,
-            args.password or settings.atproto_password,
-            silent=True,
-            required=auth_needed,
-        )
+        # only attempt login if auth is actually needed
+        # this prevents switching PDS when reading from other repos
+        if auth_needed:
+            await login(
+                client,
+                args.handle or settings.atproto_handle,
+                args.password or settings.atproto_password,
+                silent=True,
+                required=True,
+            )
 
         if args.command in ("list", "ls"):
             output_fmt = OutputFormat(args.output) if args.output else None


### PR DESCRIPTION
fixes issue where login would switch PDS endpoint, preventing reads from other repos

**problem**: when using `--repo` to read from another user's repo, the CLI would still attempt login if credentials were present in environment. this caused the atproto client to switch its PDS endpoint to the authenticated user's PDS, making other repos unreachable.

**solution**: only call `login()` when auth is actually required for the operation

**test**:
```bash
# this now works without auth
pdsx -r did:plc:p3qjmlvg74omu2fv5ctylzkm ls app.bsky.actor.profile -o json
```

fixes the 'Could not find repo' error when reading public data