### PR TITLE
fix: use importlib.metadata for dynamic version detection

### DIFF
--- a/src/pdsx/__init__.py
+++ b/src/pdsx/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
-__version__ = "0.0.0"
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version("pdsx")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"  # fallback for development mode
 
 __all__ = ["__version__"]

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -13,6 +13,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
 
 from atproto import AsyncClient  # noqa: E402
 
+from pdsx import __version__  # noqa: E402
 from pdsx._internal.auth import login  # noqa: E402
 from pdsx._internal.config import settings  # noqa: E402
 from pdsx._internal.display import (  # noqa: E402
@@ -93,7 +94,7 @@ async def async_main() -> int:
         "-v",
         "--version",
         action="version",
-        version=f"pdsx {__import__('pdsx').__version__}",
+        version=f"pdsx {__version__}",
     )
 
     # global identity flag - can be handle or DID

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ def test_version_flag_long() -> None:
     assert result.returncode == 0
     output = result.stdout.strip()
     assert output.startswith("pdsx ")
+    # ensure we're not showing the hardcoded fallback version
+    assert output != "pdsx 0.0.0"
 
 
 def test_version_flag_short() -> None:


### PR DESCRIPTION
## summary

fixes the `--version` flag to show the actual dynamic version from git tags instead of hardcoded `0.0.0`

## changes

- replaced hardcoded `__version__ = "0.0.0"` in `__init__.py` with `importlib.metadata.version("pdsx")`
- removed strange `__import__('pdsx').__version__` pattern in cli.py and replaced with normal import
- added try/except fallback for development mode (when package not installed)
- enhanced regression test to verify version is not the hardcoded fallback

## before

```bash
$ pdsx --version
pdsx 0.0.0
```

## after

```bash
$ pdsx --version
pdsx 0.0.1a2.dev7+b9da110
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)