### PR TITLE
fix: remove broken logo/favicon from docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "pdsx",
-  "logo": {
-    "dark": "/assets/logo.png",
-    "light": "/assets/logo.png"
-  },
-  "favicon": "/assets/favicon.png",
   "colors": {
     "dark": "#0D9373",
     "light": "#07C983",


### PR DESCRIPTION
removes logo and favicon references from docs.json since the asset files don't exist

fixes the broken image display in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)