### PR TITLE
docs: use zzstoatzz.io in examples instead of jlowin.dev

### DIFF
--- a/docs/concepts/addressing.mdx
+++ b/docs/concepts/addressing.mdx
@@ -55,7 +55,7 @@ dids are:
 ### using handles
 
 ```
-at://jlowin.dev/app.bsky.feed.post/3jwdwj2ctlk26
+at://zzstoatzz.io/app.bsky.feed.post/3jwdwj2ctlk26
 ```
 
 handles are:
@@ -73,13 +73,13 @@ handles are:
 ### with -r flag (handle)
 
 ```bash
-pdsx -r jlowin.dev ls app.bsky.feed.post
+pdsx -r zzstoatzz.io ls app.bsky.feed.post
 ```
 
 resolution flow:
 1. resolve handle → did
-   - try dns: `_atproto.jlowin.dev` txt record
-   - fallback to https: `https://jlowin.dev/.well-known/atproto-did`
+   - try dns: `_atproto.zzstoatzz.io` txt record
+   - fallback to https: `https://zzstoatzz.io/.well-known/atproto-did`
 2. resolve did → pds url
    - fetch did document
    - extract pds endpoint
@@ -144,7 +144,7 @@ dids resolve to **did documents** that contain:
 ```json
 {
   "id": "did:plc:44ybard66vv44zksje25o7dz",
-  "alsoKnownAs": ["at://jlowin.dev"],
+  "alsoKnownAs": ["at://zzstoatzz.io"],
   "verificationMethod": [
     {
       "id": "#atproto",
@@ -292,7 +292,7 @@ at://authority/rkey                  # missing collection
 
 **-r flag specifies repository**: can be handle or did
 ```bash
-pdsx -r jlowin.dev ls collection     # handle
+pdsx -r zzstoatzz.io ls collection     # handle
 pdsx -r did:plc:abc123 ls collection  # did
 ```
 
@@ -318,7 +318,7 @@ these addressing concepts translate directly to pdsx usage:
 
 **reading with handle**:
 ```bash
-pdsx -r jlowin.dev ls app.bsky.feed.post
+pdsx -r zzstoatzz.io ls app.bsky.feed.post
 ```
 pdsx resolves handle → DID → PDS → fetches records
 

--- a/docs/concepts/repositories.mdx
+++ b/docs/concepts/repositories.mdx
@@ -122,7 +122,7 @@ anyone can read public records from any repository:
 
 ```bash
 # no auth needed - reading someone else's public data
-pdsx -r jlowin.dev ls app.bsky.feed.post
+pdsx -r zzstoatzz.io ls app.bsky.feed.post
 ```
 
 pdsx resolves the handle → did → pds location → fetches records
@@ -240,7 +240,7 @@ the repository model maps directly to pdsx commands:
 **reading from any repository** (no auth needed):
 ```bash
 # using handle
-pdsx -r jlowin.dev ls app.bsky.feed.post
+pdsx -r zzstoatzz.io ls app.bsky.feed.post
 
 # using DID (more durable)
 pdsx -r did:plc:44ybard66vv44zksje25o7dz ls app.bsky.feed.post

--- a/docs/guides/read-repositories.mdx
+++ b/docs/guides/read-repositories.mdx
@@ -12,7 +12,7 @@ pdsx can read public records from any repository without authentication using th
 ### read with handle
 
 ```bash
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 5
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 5
 ```
 
 pdsx resolves:
@@ -36,11 +36,11 @@ handles can change or be reassigned. DIDs are permanent. use DIDs for automation
 
 ```bash
 # first page
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 10
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 10
 # next page cursor: 3lyqmkpiprs2w
 
 # next page
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 10 --cursor 3lyqmkpiprs2w
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 10 --cursor 3lyqmkpiprs2w
 ```
 
 cursors are opaque tokens. for json/yaml output, they go to stderr.
@@ -49,23 +49,23 @@ cursors are opaque tokens. for json/yaml output, they go to stderr.
 
 ```bash
 # json (for jq pipelines)
-pdsx -r jlowin.dev ls app.bsky.feed.post -o json | jq -r '.[].text'
+pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq -r '.[].text'
 
 # yaml
-pdsx -r jlowin.dev ls app.bsky.actor.profile -o yaml
+pdsx -r zzstoatzz.io ls app.bsky.actor.profile -o yaml
 
 # table
-pdsx -r jlowin.dev ls app.bsky.feed.post -o table --limit 5
+pdsx -r zzstoatzz.io ls app.bsky.feed.post -o table --limit 5
 
 # compact (default)
-pdsx -r jlowin.dev ls app.bsky.feed.post
+pdsx -r zzstoatzz.io ls app.bsky.feed.post
 ```
 
 ## examples
 
 ```bash
 # read someone's bio
-pdsx -r jlowin.dev ls app.bsky.actor.profile -o json | jq -r '.[0].description'
+pdsx -r zzstoatzz.io ls app.bsky.actor.profile -o json | jq -r '.[0].description'
 
 # get recent posts
 pdsx -r did:plc:o53crari67ge7bvbv273lxln ls app.bsky.feed.post --limit 3 -o json

--- a/docs/guides/uri-troubleshooting.mdx
+++ b/docs/guides/uri-troubleshooting.mdx
@@ -45,7 +45,7 @@ scheme      (DID or handle)
 
 ```bash
 # get URI from ls output
-pdsx -r jlowin.dev ls app.bsky.feed.post -o json | jq -r '.[0].uri'
+pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq -r '.[0].uri'
 ```
 
 ## shorthand examples
@@ -66,7 +66,7 @@ DIDs are permanent. handles can change or be reassigned. use DIDs for durable re
 at://did:plc:44ybard66vv44zksje25o7dz/app.bsky.feed.post/3jwdwj2ctlk26
 
 # handle (fragile)
-at://jlowin.dev/app.bsky.feed.post/3jwdwj2ctlk26
+at://zzstoatzz.io/app.bsky.feed.post/3jwdwj2ctlk26
 ```
 
 ## what's next

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -24,13 +24,13 @@ read anyone's public records without authentication:
 
 ```bash
 # list someone's posts
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 5
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 5
 
 # get their profile
-pdsx -r jlowin.dev get app.bsky.actor.profile/self
+pdsx -r zzstoatzz.io get app.bsky.actor.profile/self
 
 # use json output with jq
-pdsx -r jlowin.dev ls app.bsky.feed.post -o json | jq -r '.[] | .text'
+pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq -r '.[] | .text'
 ```
 
 **tip**: `-r` is the repo flag - it can be a handle or did


### PR DESCRIPTION
replaces all example handle references to use your handle instead of someone else's

🤖 Generated with [Claude Code](https://claude.com/claude-code)