### PR TITLE
fix: use ls instead of get with -r flag in quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -26,8 +26,8 @@ read anyone's public records without authentication:
 # list someone's posts
 pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 5
 
-# get their profile
-pdsx -r zzstoatzz.io get app.bsky.actor.profile/self
+# read their profile
+pdsx -r zzstoatzz.io ls app.bsky.actor.profile -o json | jq -r '.[0].description'
 
 # use json output with jq
 pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq -r '.[] | .text'


### PR DESCRIPTION
fixes invalid example that used shorthand get with -r flag

shorthand  only works when authenticated, not with 
changed to use dist
docs
justfile
LICENSE
pyproject.toml
README.md
repros
sandbox
src
tests
uv.lock which works for reading other repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)