### PR TITLE
improve: clarify CLI help and README with flag ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ uvx pdsx --help
 
 ## quick start
 
-```bash
-# read anyone's posts (no auth)
-uvx pdsx -r did:plc:o53crari67ge7bvbv273lxln ls app.bsky.feed.post -o json | jq -r '.[].text'
+**important**: flags like `-r`, `--handle`, `--password` go BEFORE the command (`ls`, `get`, etc.)
 
-# update your bio (with auth)
-export ATPROTO_HANDLE=your.handle ATPROTO_PASSWORD=your-password
+```bash
+# read anyone's posts (no auth needed)
+uvx pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq -r '.[].text'
+
+# update your bio (requires auth)
+export ATPROTO_HANDLE=your.handle ATPROTO_PASSWORD=your-app-password
 uvx pdsx edit app.bsky.actor.profile/self description='new bio'
 ```
 
@@ -38,27 +40,27 @@ uvx pdsx edit app.bsky.actor.profile/self description='new bio'
 <details>
 <summary>usage examples</summary>
 
-### read operations (no auth with --repo)
+### read operations (no auth with -r)
 
 ```bash
-# list records from any repo
-pdsx -r did:plc:... ls app.bsky.feed.post --limit 5 -o json
+# list records from any repo (note: -r goes BEFORE ls)
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 5 -o json
 
 # read someone's bio
-pdsx -r did:plc:o53crari67ge7bvbv273lxln ls app.bsky.actor.profile -o json | jq -r '.[0].description'
+pdsx -r zzstoatzz.io ls app.bsky.actor.profile -o json | jq -r '.[0].description'
 ```
 
 ### pagination
 
 ```bash
-# get first page of posts
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 10
+# get first page (note: -r before ls, --cursor after)
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 10
 
 # output includes cursor if more pages exist:
 # next page cursor: 3lyqmkpiprs2w
 
-# get next page using cursor
-pdsx -r jlowin.dev ls app.bsky.feed.post --limit 10 --cursor 3lyqmkpiprs2w
+# get next page
+pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 10 --cursor 3lyqmkpiprs2w
 ```
 
 ### blob upload (auth required)

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -119,6 +119,23 @@ async def async_main() -> int:
     """main entry point."""
     parser = argparse.ArgumentParser(
         description="atproto record operations",
+        epilog="""
+examples:
+  # read anyone's posts (no auth needed)
+  pdsx -r zzstoatzz.io ls app.bsky.feed.post
+
+  # read with DID (more durable than handle)
+  pdsx -r did:plc:abc123 ls app.bsky.feed.post
+
+  # list your own records (requires auth)
+  pdsx --handle you.bsky.social --password xxxx-xxxx ls app.bsky.feed.post
+
+  # create a record (requires auth)
+  pdsx --handle you.bsky.social create app.bsky.feed.post text='hello'
+
+note: -r flag goes BEFORE the command (ls, get, etc.)
+      auth flags (--handle, --password) also go BEFORE the command
+        """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
@@ -134,13 +151,23 @@ async def async_main() -> int:
     parser.add_argument(
         "-r",
         "--repo",
-        help="handle or DID to operate on (for reads without auth, or to specify target repo)",
+        metavar="REPO",
+        help="read from another repo (handle or DID) - no auth needed for public data",
     )
 
     # auth options (only needed for writes to your own repo)
-    parser.add_argument("--handle", help="atproto handle for authentication")
-    parser.add_argument("--password", help="atproto password for authentication")
-    parser.add_argument("--pds", help="pds url (default: https://bsky.social)")
+    parser.add_argument(
+        "--handle",
+        help="your atproto handle for authentication (required for writes)",
+    )
+    parser.add_argument(
+        "--password",
+        help="your atproto app password (get from Bluesky settings)",
+    )
+    parser.add_argument(
+        "--pds",
+        help="custom PDS URL (default: https://bsky.social)",
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="command")
 


### PR DESCRIPTION
fixes the most common user error - putting flags in the wrong place

**changes**:
- added examples section to `--help` output showing correct usage
- clarified `-r` flag: 'read from another repo (handle or DID) - no auth needed'
- improved `--handle` and `--password` descriptions
- added explicit note in both help and README: 'flags go BEFORE the command'
- updated all README examples with correct flag placement
- replaced old handle references with zzstoatzz.io

**why**:
every agent (and likely human users) keeps putting `-r` after the command instead of before it. this should make it crystal clear.

**help output now shows**:
```
examples:
  # read anyone's posts (no auth needed)
  pdsx -r zzstoatzz.io ls app.bsky.feed.post

  # read with DID (more durable than handle)
  pdsx -r did:plc:abc123 ls app.bsky.feed.post

note: -r flag goes BEFORE the command (ls, get, etc.)
      auth flags (--handle, --password) also go BEFORE the command
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)