### PR TITLE
feat: add describe_repo to list collections in a repo

### DIFF
--- a/docs/api-reference/pdsx-_internal-display.mdx
+++ b/docs/api-reference/pdsx-_internal-display.mdx
@@ -49,7 +49,21 @@ display a single record.
 - `output_format`: output format enum (default\: table with panel)
 
 
-### `display_success` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/display.py#L197" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `display_repo_description` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/display.py#L197" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+display_repo_description(response: models.ComAtprotoRepoDescribeRepo.Response) -> None
+```
+
+
+display a repo description.
+
+**Args:**
+- `response`: describe_repo response
+- `output_format`: output format enum
+
+
+### `display_success` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/display.py#L260" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 display_success(operation: str, uri: str, cid: str, collection: str = '', handle: str = '') -> None

--- a/docs/api-reference/pdsx-_internal-operations.mdx
+++ b/docs/api-reference/pdsx-_internal-operations.mdx
@@ -98,7 +98,24 @@ delete a record.
 - `uri`: record AT-URI (can be shorthand like 'collection/rkey' if authenticated)
 
 
-### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+describe_repo(client: AsyncClient, repo: str) -> models.ComAtprotoRepoDescribeRepo.Response
+```
+
+
+describe a repo, listing its collections.
+
+**Args:**
+- `client`: atproto client (no auth required)
+- `repo`: handle or DID to describe
+
+**Returns:**
+- response with handle, did, didDoc, collections, handleIsCorrect
+
+
+### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L216" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 upload_blob(client: AsyncClient, file_path: str | Path) -> models.ComAtprotoRepoUploadBlob.Response

--- a/docs/api-reference/pdsx-cli.mdx
+++ b/docs/api-reference/pdsx-cli.mdx
@@ -10,7 +10,7 @@ general-purpose cli for atproto record operations.
 
 ## Functions
 
-### `cmd_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L48" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L50" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_list(client: AsyncClient, collection: str, limit: int, repo: str | None = None, cursor: str | None = None, output_format: OutputFormat | None = None) -> None
@@ -20,7 +20,17 @@ cmd_list(client: AsyncClient, collection: str, limit: int, repo: str | None = No
 list records in a collection.
 
 
-### `cmd_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L75" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_describe` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+cmd_describe(client: AsyncClient, repo: str, output_format: OutputFormat | None = None) -> None
+```
+
+
+describe a repo, listing its collections.
+
+
+### `cmd_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_get(client: AsyncClient, uri: str, output_format: OutputFormat | None = None, repo: str | None = None) -> None
@@ -30,7 +40,7 @@ cmd_get(client: AsyncClient, uri: str, output_format: OutputFormat | None = None
 get a specific record.
 
 
-### `cmd_create` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L87" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_create` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_create(client: AsyncClient, collection: str, records: list[dict[str, RecordValue]]) -> None
@@ -40,7 +50,7 @@ cmd_create(client: AsyncClient, collection: str, records: list[dict[str, RecordV
 create one or more records.
 
 
-### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L117" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L130" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordValue]]]) -> None
@@ -50,7 +60,7 @@ cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordVa
 update one or more records.
 
 
-### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L144" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L157" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_delete(client: AsyncClient, uris: list[str]) -> None
@@ -60,7 +70,7 @@ cmd_delete(client: AsyncClient, uris: list[str]) -> None
 delete one or more records.
 
 
-### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L170" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_upload_blob(client: AsyncClient, file_path: str) -> None
@@ -70,7 +80,7 @@ cmd_upload_blob(client: AsyncClient, file_path: str) -> None
 upload a blob (image, video, etc.).
 
 
-### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_whoami(client: AsyncClient) -> None
@@ -80,7 +90,7 @@ cmd_whoami(client: AsyncClient) -> None
 show authenticated identity.
 
 
-### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L213" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 async_main() -> int
@@ -90,7 +100,7 @@ async_main() -> int
 main entry point.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L529" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L551" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> NoReturn

--- a/docs/api-reference/pdsx-mcp-_types.mdx
+++ b/docs/api-reference/pdsx-mcp-_types.mdx
@@ -40,7 +40,13 @@ response from deleting a record.
 response from whoami/identity check.
 
 
-### `CredentialsContext` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/_types.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `RepoDescriptionResponse` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/_types.py#L41" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+response from describing a repo.
+
+
+### `CredentialsContext` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/_types.py#L50" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 credentials extracted from context or headers.

--- a/docs/api-reference/pdsx-mcp-server.mdx
+++ b/docs/api-reference/pdsx-mcp-server.mdx
@@ -10,7 +10,7 @@ pdsx MCP server implementation using fastmcp.
 
 ## Functions
 
-### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L51" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _clean_value(value: Any) -> dict[str, Any]
@@ -26,7 +26,7 @@ removes:
 - verbose reply structure (keeps just uris)
 
 
-### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L117" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L121" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _truncate_list_response(records: list[RecordResponse], total_fetched: int, has_more: bool) -> list[RecordResponse] | dict[str, Any]
@@ -38,7 +38,7 @@ truncate list response if it exceeds size limits.
 returns either the original list or a dict with truncated results and a message.
 
 
-### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L160" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L164" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 usage_guide() -> str
@@ -48,7 +48,7 @@ usage_guide() -> str
 instructions for using pdsx MCP tools.
 
 
-### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L195" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L199" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_post_guide() -> str
@@ -58,7 +58,7 @@ create_post_guide() -> str
 instructions for creating posts.
 
 
-### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L250" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L254" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_records(collection: str, limit: int = 10, repo: str | None = None, cursor: str | None = None) -> list[RecordResponse] | dict[str, Any]
@@ -81,7 +81,29 @@ examples:
 - list of records with uri, cid, and value fields
 
 
-### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L300" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L304" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+describe_repo(repo: str) -> RepoDescriptionResponse
+```
+
+
+describe a repo and list its collections.
+
+use this to discover what collections exist in a repo before listing records.
+
+examples:
+- describe_repo("zzstoatzz.io") - see what collections a user has
+- describe_repo("did:plc:...") - describe by DID
+
+**Args:**
+- `repo`: handle or DID to describe
+
+**Returns:**
+- dict with handle, did, collections, and handleIsCorrect
+
+
+### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L335" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_record(uri: str, repo: str | None = None) -> RecordResponse
@@ -102,7 +124,7 @@ examples:
 - record with uri, cid, and value fields
 
 
-### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L344" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L379" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_record(collection: str, record: dict[str, Any]) -> CreateResponse
@@ -119,7 +141,7 @@ create a new record. requires authentication.
 - dict with uri and cid of created record
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L366" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L401" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(uri: str, updates: dict[str, Any]) -> UpdateResponse
@@ -138,7 +160,7 @@ fetches the current record, merges your updates, and puts it back.
 - dict with uri and cid of updated record
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L390" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L425" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(uri: str) -> DeleteResponse
@@ -158,7 +180,7 @@ examples:
 - confirmation with deleted uri
 
 
-### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L416" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L451" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 whoami() -> IdentityResponse
@@ -174,7 +196,7 @@ requires authentication via x-atproto-handle and x-atproto-password headers.
 - dict with handle and did of authenticated user
 
 
-### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L440" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L475" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 me_resource() -> str
@@ -184,7 +206,7 @@ me_resource() -> str
 current authenticated user identity.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L456" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L491" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> None

--- a/src/pdsx/_internal/display.py
+++ b/src/pdsx/_internal/display.py
@@ -194,6 +194,69 @@ def display_record(
     console.print(Panel(table, title="[bold]record[/bold]", border_style="dim"))
 
 
+def display_repo_description(
+    response: models.ComAtprotoRepoDescribeRepo.Response,
+    *,
+    output_format: OutputFormat = OutputFormat.TABLE,
+) -> None:
+    """display a repo description.
+
+    Args:
+        response: describe_repo response
+        output_format: output format enum
+    """
+    handle = response.handle
+    did = response.did
+    handle_ok = response.handle_is_correct
+    collections = response.collections or []
+
+    # json output
+    if output_format == OutputFormat.JSON:
+        output = {
+            "handle": handle,
+            "did": did,
+            "handleIsCorrect": handle_ok,
+            "collections": collections,
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    # yaml output
+    if output_format == OutputFormat.YAML:
+        output = {
+            "handle": handle,
+            "did": did,
+            "handleIsCorrect": handle_ok,
+            "collections": collections,
+        }
+        print(yaml.dump(output, default_flow_style=False, sort_keys=False))
+        return
+
+    # compact output
+    if output_format == OutputFormat.COMPACT:
+        status = "valid" if handle_ok else "invalid"
+        print(f"{handle} ({did}) handle={status}")
+        for c in collections:
+            print(f"  {c}")
+        return
+
+    # table output (default)
+    table = Table(show_header=False, box=None)
+    table.add_column("key", style="cyan")
+    table.add_column("value", style="white")
+
+    table.add_row("handle", handle)
+    table.add_row("did", did)
+    table.add_row(
+        "handle valid", "[green]yes[/green]" if handle_ok else "[red]no[/red]"
+    )
+
+    collections_str = "\n".join(collections) if collections else "[dim]none[/dim]"
+    table.add_row("collections", collections_str)
+
+    console.print(Panel(table, title="[bold]repo[/bold]", border_style="dim"))
+
+
 def display_success(
     operation: str,
     uri: str,

--- a/src/pdsx/_internal/operations.py
+++ b/src/pdsx/_internal/operations.py
@@ -197,6 +197,22 @@ async def delete_record(
     )
 
 
+async def describe_repo(
+    client: AsyncClient,
+    repo: str,
+) -> models.ComAtprotoRepoDescribeRepo.Response:
+    """describe a repo, listing its collections.
+
+    Args:
+        client: atproto client (no auth required)
+        repo: handle or DID to describe
+
+    Returns:
+        response with handle, did, didDoc, collections, handleIsCorrect
+    """
+    return await client.com.atproto.repo.describe_repo({"repo": repo})
+
+
 async def upload_blob(
     client: AsyncClient,
     file_path: str | Path,

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -29,11 +29,13 @@ from pdsx._internal.display import (  # noqa: E402
     console,
     display_record,
     display_records,
+    display_repo_description,
     display_success,
 )
 from pdsx._internal.operations import (  # noqa: E402
     create_record,
     delete_record,
+    describe_repo,
     get_record,
     list_records,
     update_record,
@@ -70,6 +72,17 @@ async def cmd_list(
             print(f"\nnext page cursor: {response.cursor}", file=sys.stderr)
         else:
             console.print(f"\n[dim]next page cursor:[/dim] {response.cursor}")
+
+
+async def cmd_describe(
+    client: AsyncClient,
+    repo: str,
+    output_format: OutputFormat | None = None,
+) -> None:
+    """describe a repo, listing its collections."""
+    response = await describe_repo(client, repo)
+    fmt = output_format or OutputFormat.TABLE
+    display_repo_description(response, output_format=fmt)
 
 
 async def cmd_get(
@@ -203,6 +216,9 @@ async def async_main() -> int:
         description="atproto record operations",
         epilog="""
 examples:
+  # list collections in a repo
+  pdsx -r zzstoatzz.io ls
+
   # read posts (no auth needed, -r is required)
   pdsx -r zzstoatzz.io ls app.bsky.feed.post
 
@@ -253,7 +269,10 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
     # list (ls alias)
     list_parser = subparsers.add_parser("list", aliases=["ls"], help="list records")
     list_parser.add_argument(
-        "collection", help="collection name (e.g., app.bsky.feed.post)"
+        "collection",
+        nargs="?",
+        default=None,
+        help="collection name (e.g., app.bsky.feed.post). omit to list collections in the repo",
     )
     list_parser.add_argument("--limit", type=int, default=50, help="max records")
     list_parser.add_argument(
@@ -418,14 +437,17 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
 
         if args.command in ("list", "ls"):
             output_fmt = OutputFormat(args.output) if args.output else None
-            await cmd_list(
-                client,
-                args.collection,
-                args.limit,
-                args.repo,
-                args.cursor,
-                output_format=output_fmt,
-            )
+            if args.collection is None:
+                await cmd_describe(client, args.repo, output_format=output_fmt)
+            else:
+                await cmd_list(
+                    client,
+                    args.collection,
+                    args.limit,
+                    args.repo,
+                    args.cursor,
+                    output_format=output_fmt,
+                )
 
         elif args.command in ("get", "cat"):
             output_fmt = (

--- a/src/pdsx/mcp/_types.py
+++ b/src/pdsx/mcp/_types.py
@@ -38,6 +38,15 @@ class IdentityResponse(TypedDict):
     did: str
 
 
+class RepoDescriptionResponse(TypedDict):
+    """response from describing a repo."""
+
+    handle: str
+    did: str
+    collections: list[str]
+    handleIsCorrect: bool
+
+
 class CredentialsContext(TypedDict):
     """credentials extracted from context or headers."""
 

--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -12,6 +12,9 @@ from pdsx._internal.operations import (
     delete_record as _delete_record,
 )
 from pdsx._internal.operations import (
+    describe_repo as _describe_repo,
+)
+from pdsx._internal.operations import (
     get_record as _get_record,
 )
 from pdsx._internal.operations import (
@@ -26,6 +29,7 @@ from pdsx.mcp._types import (
     DeleteResponse,
     IdentityResponse,
     RecordResponse,
+    RepoDescriptionResponse,
     UpdateResponse,
 )
 from pdsx.mcp.client import (
@@ -293,6 +297,37 @@ async def list_records(
             records,
             total_fetched=len(records),
             has_more=response.cursor is not None,
+        )
+
+
+@mcp.tool
+async def describe_repo(
+    repo: str,
+) -> RepoDescriptionResponse:
+    """describe a repo and list its collections.
+
+    use this to discover what collections exist in a repo before listing records.
+
+    examples:
+    - describe_repo("zzstoatzz.io") - see what collections a user has
+    - describe_repo("did:plc:...") - describe by DID
+
+    args:
+        repo: handle or DID to describe
+
+    returns:
+        dict with handle, did, collections, and handleIsCorrect
+    """
+    async with get_atproto_client(
+        require_auth=False,
+        target_repo=repo,
+    ) as client:
+        response = await _describe_repo(client, repo)
+        return RepoDescriptionResponse(
+            handle=response.handle,
+            did=response.did,
+            collections=response.collections or [],
+            handleIsCorrect=response.handle_is_correct,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,6 +23,55 @@ def test_whoami_in_help() -> None:
     assert "whoami" in result.stdout
     assert "me" in result.stdout
     assert "identity" in result.stdout
+
+
+class TestDescribe:
+    """tests for describe (ls without collection) command."""
+
+    async def test_cmd_describe_displays_repo(self) -> None:
+        """cmd_describe shows repo info when collection omitted."""
+        from pdsx.cli import cmd_describe
+
+        mock_client = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.handle = "test.bsky.social"
+        mock_response.did = "did:plc:test123"
+        mock_response.handle_is_correct = True
+        mock_response.collections = [
+            "app.bsky.feed.post",
+            "app.bsky.actor.profile",
+        ]
+
+        with patch(
+            "pdsx.cli.describe_repo", new_callable=AsyncMock, return_value=mock_response
+        ):
+            await cmd_describe(mock_client, "test.bsky.social")
+
+    async def test_cmd_describe_json_output(self, capsys) -> None:
+        """cmd_describe outputs json when requested."""
+        from pdsx._internal.output import OutputFormat
+        from pdsx.cli import cmd_describe
+
+        mock_client = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.handle = "test.bsky.social"
+        mock_response.did = "did:plc:test123"
+        mock_response.handle_is_correct = True
+        mock_response.collections = ["app.bsky.feed.post"]
+
+        with patch(
+            "pdsx.cli.describe_repo", new_callable=AsyncMock, return_value=mock_response
+        ):
+            await cmd_describe(
+                mock_client, "test.bsky.social", output_format=OutputFormat.JSON
+            )
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert output["handle"] == "test.bsky.social"
+        assert output["collections"] == ["app.bsky.feed.post"]
 
 
 class TestWhoami:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,6 +7,7 @@ from pdsx.mcp._types import (
     CredentialsContext,
     DeleteResponse,
     RecordResponse,
+    RepoDescriptionResponse,
     UpdateResponse,
 )
 from pdsx.mcp.client import AUTH_HELP, AuthenticationRequired
@@ -58,6 +59,19 @@ class TestTypedDicts:
         """DeleteResponse can be constructed."""
         r = DeleteResponse(deleted="at://...")
         assert r["deleted"] == "at://..."
+
+    def test_repo_description_response(self):
+        """RepoDescriptionResponse can be constructed."""
+        r = RepoDescriptionResponse(
+            handle="test.bsky.social",
+            did="did:plc:test123",
+            collections=["app.bsky.feed.post", "app.bsky.actor.profile"],
+            handleIsCorrect=True,
+        )
+        assert r["handle"] == "test.bsky.social"
+        assert r["did"] == "did:plc:test123"
+        assert r["collections"] == ["app.bsky.feed.post", "app.bsky.actor.profile"]
+        assert r["handleIsCorrect"] is True
 
     def test_credentials_context(self):
         """CredentialsContext can be constructed."""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -9,6 +9,7 @@ from atproto import AsyncClient, models
 
 from pdsx._internal.operations import (
     delete_record,
+    describe_repo,
     get_record,
     list_records,
     update_record,
@@ -270,3 +271,53 @@ class TestListRecords:
         assert call_args["collection"] == "app.bsky.feed.post"
         assert call_args["limit"] == 50
         assert call_args["cursor"] == "previous_cursor"
+
+
+class TestDescribeRepo:
+    """tests for describe_repo function."""
+
+    async def test_describe_repo(self, mock_client: AsyncClient) -> None:
+        """test describing a repo returns collections."""
+        mock_response = models.ComAtprotoRepoDescribeRepo.Response(
+            handle="test.bsky.social",
+            did="did:plc:test123",
+            did_doc={},
+            collections=["app.bsky.feed.post", "app.bsky.actor.profile"],
+            handle_is_correct=True,
+        )
+        mock_client.com.atproto.repo.describe_repo = AsyncMock(  # type: ignore[attr-defined]
+            return_value=mock_response
+        )
+
+        result = await describe_repo(mock_client, "test.bsky.social")
+
+        assert result.handle == "test.bsky.social"
+        assert result.did == "did:plc:test123"
+        assert result.collections == [
+            "app.bsky.feed.post",
+            "app.bsky.actor.profile",
+        ]
+        assert result.handle_is_correct is True
+        mock_client.com.atproto.repo.describe_repo.assert_called_once_with(
+            {"repo": "test.bsky.social"}
+        )
+
+    async def test_describe_repo_no_auth_needed(
+        self, mock_client_no_auth: AsyncClient
+    ) -> None:
+        """test describe_repo works without authentication."""
+        mock_response = models.ComAtprotoRepoDescribeRepo.Response(
+            handle="other.bsky.social",
+            did="did:plc:other456",
+            did_doc={},
+            collections=["app.bsky.feed.post"],
+            handle_is_correct=True,
+        )
+        mock_client_no_auth.com.atproto.repo.describe_repo = AsyncMock(  # type: ignore[attr-defined]
+            return_value=mock_response
+        )
+
+        result = await describe_repo(mock_client_no_auth, "other.bsky.social")
+
+        assert result.handle == "other.bsky.social"
+        assert result.collections == ["app.bsky.feed.post"]


### PR DESCRIPTION
## Summary

- Makes `collection` arg optional on `pdsx ls` — when omitted, calls `com.atproto.repo.describeRepo` to show what collections exist in the repo
- Adds `describe_repo` as an MCP tool (no auth required)
- Supports all output formats (`-o json/yaml/table/compact`)

## Test plan

- [x] `pdsx -r zzstoatzz.io ls` — shows collections in the repo
- [x] `pdsx -r zzstoatzz.io ls -o json` — structured output
- [x] `pdsx -r zzstoatzz.io ls app.bsky.feed.post` — existing behavior unchanged
- [x] 132 tests pass, no regressions
- [x] ruff + type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)