### PR TITLE
feat: support rkey in create_record (CLI, SDK, MCP)

### DIFF
--- a/docs/api-reference/pdsx-_internal-batch.mdx
+++ b/docs/api-reference/pdsx-_internal-batch.mdx
@@ -43,6 +43,7 @@ create multiple records concurrently.
 - `client`: authenticated atproto client
 - `collection`: collection name
 - `records`: list of record data dictionaries
+- `rkeys`: optional list of rkeys (one per record, None for auto-generated)
 - `concurrency`: maximum concurrent operations (default\: 10)
 - `fail_fast`: stop on first error (default\: False)
 - `show_progress`: show progress bar (default\: True)
@@ -51,7 +52,7 @@ create multiple records concurrently.
 - batch result with successful URIs and failed operations
 
 
-### `batch_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L176" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `batch_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L187" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 batch_update(client: AsyncClient, updates: list[tuple[str, dict[str, RecordValue]]]) -> BatchResult
@@ -71,7 +72,7 @@ update multiple records concurrently.
 - batch result with successful URIs and failed operations
 
 
-### `read_uris_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L241" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `read_uris_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L252" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 read_uris_from_stdin() -> list[str]
@@ -84,23 +85,25 @@ read URIs from stdin, one per line.
 - list of URIs read from stdin
 
 
-### `read_records_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L253" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `read_records_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L264" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-read_records_from_stdin() -> list[dict[str, RecordValue]]
+read_records_from_stdin() -> list[tuple[dict[str, RecordValue], str | None]]
 ```
 
 
 read JSONL records from stdin, one JSON object per line.
 
+if a record contains an 'rkey' field, it is extracted and returned separately.
+
 **Returns:**
-- list of record dictionaries parsed from JSONL
+- list of (record_dict, rkey_or_none) tuples parsed from JSONL
 
 **Raises:**
 - `ValueError`: if JSON parsing fails
 
 
-### `read_updates_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L285" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `read_updates_from_stdin` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L301" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 read_updates_from_stdin() -> list[tuple[str, dict[str, RecordValue]]]
@@ -118,7 +121,7 @@ each line should be a JSON object with a 'uri' field and update fields.
 - `ValueError`: if JSON parsing fails or uri field is missing
 
 
-### `display_batch_result` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L330" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `display_batch_result` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/batch.py#L346" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 display_batch_result(result: BatchResult, operation: str = 'deleted') -> None

--- a/docs/api-reference/pdsx-_internal-operations.mdx
+++ b/docs/api-reference/pdsx-_internal-operations.mdx
@@ -51,7 +51,7 @@ get a specific record.
 ### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-create_record(client: AsyncClient, collection: str, record: dict[str, RecordValue]) -> models.ComAtprotoRepoCreateRecord.Response
+create_record(client: AsyncClient, collection: str, record: dict[str, RecordValue], rkey: str | None = None) -> models.ComAtprotoRepoCreateRecord.Response
 ```
 
 
@@ -61,12 +61,13 @@ create a new record.
 - `client`: authenticated atproto client
 - `collection`: collection name
 - `record`: record data
+- `rkey`: optional record key (e.g. 'self' for profile records)
 
 **Returns:**
 - created record response
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L135" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L140" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(client: AsyncClient, uri: str, updates: dict[str, RecordValue]) -> models.ComAtprotoRepoPutRecord.Response
@@ -84,7 +85,7 @@ update an existing record.
 - updated record response
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L179" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(client: AsyncClient, uri: str) -> None
@@ -98,7 +99,7 @@ delete a record.
 - `uri`: record AT-URI (can be shorthand like 'collection/rkey' if authenticated)
 
 
-### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 describe_repo(client: AsyncClient, repo: str) -> models.ComAtprotoRepoDescribeRepo.Response
@@ -115,7 +116,7 @@ describe a repo, listing its collections.
 - response with handle, did, didDoc, collections, handleIsCorrect
 
 
-### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L216" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L221" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 upload_blob(client: AsyncClient, file_path: str | Path) -> models.ComAtprotoRepoUploadBlob.Response

--- a/docs/api-reference/pdsx-cli.mdx
+++ b/docs/api-reference/pdsx-cli.mdx
@@ -50,7 +50,7 @@ cmd_create(client: AsyncClient, collection: str, records: list[dict[str, RecordV
 create one or more records.
 
 
-### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L130" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L131" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordValue]]]) -> None
@@ -60,7 +60,7 @@ cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordVa
 update one or more records.
 
 
-### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L157" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L158" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_delete(client: AsyncClient, uris: list[str]) -> None
@@ -70,7 +70,7 @@ cmd_delete(client: AsyncClient, uris: list[str]) -> None
 delete one or more records.
 
 
-### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_upload_blob(client: AsyncClient, file_path: str) -> None
@@ -80,7 +80,7 @@ cmd_upload_blob(client: AsyncClient, file_path: str) -> None
 upload a blob (image, video, etc.).
 
 
-### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L204" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_whoami(client: AsyncClient) -> None
@@ -90,7 +90,7 @@ cmd_whoami(client: AsyncClient) -> None
 show authenticated identity.
 
 
-### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L213" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L214" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 async_main() -> int
@@ -100,7 +100,7 @@ async_main() -> int
 main entry point.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L551" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L584" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> NoReturn

--- a/docs/api-reference/pdsx-mcp-server.mdx
+++ b/docs/api-reference/pdsx-mcp-server.mdx
@@ -127,7 +127,7 @@ examples:
 ### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L379" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-create_record(collection: str, record: dict[str, Any]) -> CreateResponse
+create_record(collection: str, record: dict[str, Any], rkey: str | None = None) -> CreateResponse
 ```
 
 
@@ -136,12 +136,14 @@ create a new record. requires authentication.
 **Args:**
 - `collection`: the collection to create in (e.g., 'app.bsky.feed.post')
 - `record`: the record data. $type and createdAt are auto-added if missing.
+- `rkey`: optional record key (e.g., 'self' for profile records, or any fixed key
+  required by the lexicon). auto-generated if not provided.
 
 **Returns:**
 - dict with uri and cid of created record
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L401" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L404" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(uri: str, updates: dict[str, Any]) -> UpdateResponse
@@ -160,7 +162,7 @@ fetches the current record, merges your updates, and puts it back.
 - dict with uri and cid of updated record
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L425" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L428" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(uri: str) -> DeleteResponse
@@ -180,7 +182,7 @@ examples:
 - confirmation with deleted uri
 
 
-### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L451" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L454" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 whoami() -> IdentityResponse
@@ -196,7 +198,7 @@ requires authentication via x-atproto-handle and x-atproto-password headers.
 - dict with handle and did of authenticated user
 
 
-### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L475" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L478" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 me_resource() -> str
@@ -206,7 +208,7 @@ me_resource() -> str
 current authenticated user identity.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L491" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L494" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> None

--- a/src/pdsx/_internal/batch.py
+++ b/src/pdsx/_internal/batch.py
@@ -108,6 +108,7 @@ async def batch_create(
     collection: str,
     records: list[dict[str, RecordValue]],
     *,
+    rkeys: list[str | None] | None = None,
     concurrency: int = 10,
     fail_fast: bool = False,
     show_progress: bool = True,
@@ -118,6 +119,7 @@ async def batch_create(
         client: authenticated atproto client
         collection: collection name
         records: list of record data dictionaries
+        rkeys: optional list of rkeys (one per record, None for auto-generated)
         concurrency: maximum concurrent operations (default: 10)
         fail_fast: stop on first error (default: False)
         show_progress: show progress bar (default: True)
@@ -144,11 +146,13 @@ async def batch_create(
         progress.start()
         task_id = progress.add_task("creating records", total=len(records))
 
-    async def create_one(record: dict[str, RecordValue], index: int) -> None:
+    async def create_one(
+        record: dict[str, RecordValue], index: int, rkey: str | None = None
+    ) -> None:
         """create a single record with concurrency control."""
         async with semaphore:
             try:
-                response = await create_record(client, collection, record)
+                response = await create_record(client, collection, record, rkey=rkey)
                 successful.append(response.uri)
             except Exception as e:
                 # use index as identifier since we don't have URI yet
@@ -159,9 +163,16 @@ async def batch_create(
                 if progress and task_id is not None:
                     progress.update(task_id, advance=1)
 
+    resolved_rkeys = rkeys or [None] * len(records)
+
     try:
         await asyncio.gather(
-            *[create_one(record, i) for i, record in enumerate(records)]
+            *[
+                create_one(record, i, rkey)
+                for i, (record, rkey) in enumerate(
+                    zip(records, resolved_rkeys, strict=False)
+                )
+            ]
         )
     except Exception:
         # fail_fast raised an exception
@@ -250,11 +261,13 @@ def read_uris_from_stdin() -> list[str]:
     return [line.strip() for line in sys.stdin if line.strip()]
 
 
-def read_records_from_stdin() -> list[dict[str, RecordValue]]:
+def read_records_from_stdin() -> list[tuple[dict[str, RecordValue], str | None]]:
     """read JSONL records from stdin, one JSON object per line.
 
+    if a record contains an 'rkey' field, it is extracted and returned separately.
+
     Returns:
-        list of record dictionaries parsed from JSONL
+        list of (record_dict, rkey_or_none) tuples parsed from JSONL
 
     Raises:
         ValueError: if JSON parsing fails
@@ -264,7 +277,7 @@ def read_records_from_stdin() -> list[dict[str, RecordValue]]:
     if sys.stdin.isatty():
         return []
 
-    records = []
+    results: list[tuple[dict[str, RecordValue], str | None]] = []
     for line_num, line in enumerate(sys.stdin, start=1):
         line = line.strip()
         if not line:
@@ -275,11 +288,14 @@ def read_records_from_stdin() -> list[dict[str, RecordValue]]:
                 raise ValueError(
                     f"line {line_num}: expected JSON object, got {type(record).__name__}"
                 )
-            records.append(record)
+            rkey = record.pop("rkey", None)
+            if rkey is not None and not isinstance(rkey, str):
+                raise ValueError(f"line {line_num}: 'rkey' must be a string")
+            results.append((record, rkey))
         except json.JSONDecodeError as e:
             raise ValueError(f"line {line_num}: invalid JSON - {e}") from e
 
-    return records
+    return results
 
 
 def read_updates_from_stdin() -> list[tuple[str, dict[str, RecordValue]]]:

--- a/src/pdsx/_internal/operations.py
+++ b/src/pdsx/_internal/operations.py
@@ -101,6 +101,7 @@ async def create_record(
     client: AsyncClient,
     collection: str,
     record: dict[str, RecordValue],
+    rkey: str | None = None,
 ) -> models.ComAtprotoRepoCreateRecord.Response:
     """create a new record.
 
@@ -108,6 +109,7 @@ async def create_record(
         client: authenticated atproto client
         collection: collection name
         record: record data
+        rkey: optional record key (e.g. 'self' for profile records)
 
     Returns:
         created record response
@@ -123,13 +125,16 @@ async def create_record(
     if "createdAt" not in record:
         record["createdAt"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
-    return await client.com.atproto.repo.create_record(
-        {
-            "repo": client.me.did,
-            "collection": collection,
-            "record": record,
-        }
-    )
+    params: dict[str, str | dict[str, RecordValue]] = {
+        "repo": client.me.did,
+        "collection": collection,
+        "record": record,
+    }
+
+    if rkey is not None:
+        params["rkey"] = rkey
+
+    return await client.com.atproto.repo.create_record(params)
 
 
 async def update_record(

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -102,6 +102,7 @@ async def cmd_create(
     collection: str,
     records: list[dict[str, RecordValue]],
     *,
+    rkey: str | None = None,
     concurrency: int = 10,
     fail_fast: bool = False,
 ) -> None:
@@ -110,7 +111,7 @@ async def cmd_create(
 
     # single record - use existing behavior for backward compatibility
     if len(records) == 1:
-        response = await create_record(client, collection, records[0])
+        response = await create_record(client, collection, records[0], rkey=rkey)
         display_success("created", response.uri, response.cid, collection, handle)
         return
 
@@ -313,6 +314,10 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
         help="max concurrent operations for batch create (default: 10)",
     )
     create_parser.add_argument(
+        "--rkey",
+        help="record key (e.g., 'self' for profile records)",
+    )
+    create_parser.add_argument(
         "--fail-fast",
         action="store_true",
         help="stop on first error (default: continue on error)",
@@ -461,13 +466,26 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
                 # single record from command line args
                 record = parse_key_value_args(args.fields)
                 records = [record]
+                rkeys: list[str | None] | None = None
+                rkey = args.rkey
             else:
                 # batch records from stdin (JSONL format)
+                # each record may have its own rkey
                 try:
-                    records = read_records_from_stdin()
+                    parsed = read_records_from_stdin()
                 except ValueError as e:
                     console.print(f"[red]error:[/red] {e}")
                     return 1
+
+                if not parsed:
+                    console.print(
+                        "[red]error:[/red] no records provided (use key=value arguments or pipe JSONL to stdin)"
+                    )
+                    return 1
+
+                records = [r for r, _ in parsed]
+                rkeys = [rk for _, rk in parsed]
+                rkey = args.rkey  # CLI --rkey overrides per-record rkeys for single
 
             if not records:
                 console.print(
@@ -475,13 +493,28 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
                 )
                 return 1
 
-            await cmd_create(
-                client,
-                args.collection,
-                records,
-                concurrency=args.concurrency,
-                fail_fast=args.fail_fast,
-            )
+            if len(records) == 1:
+                await cmd_create(
+                    client,
+                    args.collection,
+                    records,
+                    rkey=rkey or (rkeys[0] if rkeys else None),
+                    concurrency=args.concurrency,
+                    fail_fast=args.fail_fast,
+                )
+            else:
+                # batch: use per-record rkeys from JSONL
+                show_progress = sys.stdout.isatty()
+                result = await batch_create(
+                    client,
+                    args.collection,
+                    records,
+                    rkeys=rkeys,
+                    concurrency=args.concurrency,
+                    fail_fast=args.fail_fast,
+                    show_progress=show_progress,
+                )
+                display_batch_result(result, "created")
 
         elif args.command in ("update", "edit"):
             # support batch update from stdin (JSONL) or single update from args

--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -379,12 +379,15 @@ async def get_record(
 async def create_record(
     collection: str,
     record: dict[str, Any],
+    rkey: str | None = None,
 ) -> CreateResponse:
     """create a new record. requires authentication.
 
     args:
         collection: the collection to create in (e.g., 'app.bsky.feed.post')
         record: the record data. $type and createdAt are auto-added if missing.
+        rkey: optional record key (e.g., 'self' for profile records, or any fixed key
+              required by the lexicon). auto-generated if not provided.
 
     returns:
         dict with uri and cid of created record
@@ -393,7 +396,7 @@ async def create_record(
         require_auth=True,
         operation="creating a record",
     ) as client:
-        response = await _create_record(client, collection, record)
+        response = await _create_record(client, collection, record, rkey=rkey)
         return CreateResponse(uri=response.uri, cid=response.cid)
 
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -256,7 +256,7 @@ class TestBatchCreate:
         ]
 
         async def mock_create(
-            client: AsyncClient, collection: str, record: dict
+            client: AsyncClient, collection: str, record: dict, **kwargs
         ) -> MagicMock:
             """mock create that fails on second record."""
             if record["text"] == "post 2":
@@ -307,12 +307,31 @@ class TestReadRecordsFromStdin:
             patch("sys.stdin", io.StringIO(test_input)),
             patch("sys.stdin.isatty", return_value=False),
         ):
-            records = read_records_from_stdin()
+            results = read_records_from_stdin()
 
-        assert len(records) == 3
-        assert records[0] == {"text": "post 1"}
-        assert records[1] == {"text": "post 2"}
-        assert records[2] == {"text": "post 3"}
+        assert len(results) == 3
+        assert results[0] == ({"text": "post 1"}, None)
+        assert results[1] == ({"text": "post 2"}, None)
+        assert results[2] == ({"text": "post 3"}, None)
+
+    def test_read_jsonl_with_rkey(self) -> None:
+        """test reading JSONL records with rkey field."""
+        import io
+
+        test_input = '{"rkey":"self","displayName":"Test"}\n{"text":"no rkey"}\n'
+
+        with (
+            patch("sys.stdin", io.StringIO(test_input)),
+            patch("sys.stdin.isatty", return_value=False),
+        ):
+            results = read_records_from_stdin()
+
+        assert len(results) == 2
+        record, rkey = results[0]
+        assert rkey == "self"
+        assert "rkey" not in record  # rkey is popped from the record
+        assert record == {"displayName": "Test"}
+        assert results[1] == ({"text": "no rkey"}, None)
 
     def test_read_jsonl_with_empty_lines(self) -> None:
         """test reading JSONL with empty lines."""
@@ -324,10 +343,10 @@ class TestReadRecordsFromStdin:
             patch("sys.stdin", io.StringIO(test_input)),
             patch("sys.stdin.isatty", return_value=False),
         ):
-            records = read_records_from_stdin()
+            results = read_records_from_stdin()
 
-        assert len(records) == 3
-        assert records[0] == {"text": "post 1"}
+        assert len(results) == 3
+        assert results[0] == ({"text": "post 1"}, None)
 
     def test_invalid_json_raises_error(self) -> None:
         """test invalid JSON raises ValueError."""

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -8,6 +8,7 @@ import pytest
 from atproto import AsyncClient, models
 
 from pdsx._internal.operations import (
+    create_record,
     delete_record,
     describe_repo,
     get_record,
@@ -271,6 +272,88 @@ class TestListRecords:
         assert call_args["collection"] == "app.bsky.feed.post"
         assert call_args["limit"] == 50
         assert call_args["cursor"] == "previous_cursor"
+
+
+class TestCreateRecord:
+    """tests for create_record function."""
+
+    async def test_basic_create(self, mock_client: AsyncClient) -> None:
+        """test basic record creation."""
+        mock_client.com.atproto.repo.create_record = AsyncMock(  # type: ignore[attr-defined]
+            return_value=models.ComAtprotoRepoCreateRecord.Response(
+                uri="at://did:plc:test123/app.bsky.feed.post/abc123",
+                cid="testcid",
+            )
+        )
+
+        result = await create_record(
+            mock_client,
+            "app.bsky.feed.post",
+            {"text": "hello"},
+        )
+
+        assert result.uri == "at://did:plc:test123/app.bsky.feed.post/abc123"
+        mock_client.com.atproto.repo.create_record.assert_called_once()
+        call_args = mock_client.com.atproto.repo.create_record.call_args[0][0]
+        assert call_args["repo"] == "did:plc:test123"
+        assert call_args["collection"] == "app.bsky.feed.post"
+        assert call_args["record"]["text"] == "hello"
+        assert call_args["record"]["$type"] == "app.bsky.feed.post"
+        assert "createdAt" in call_args["record"]
+        assert "rkey" not in call_args
+
+    async def test_create_with_rkey(self, mock_client: AsyncClient) -> None:
+        """test record creation with explicit rkey."""
+        mock_client.com.atproto.repo.create_record = AsyncMock(  # type: ignore[attr-defined]
+            return_value=models.ComAtprotoRepoCreateRecord.Response(
+                uri="at://did:plc:test123/app.bsky.actor.profile/self",
+                cid="testcid",
+            )
+        )
+
+        result = await create_record(
+            mock_client,
+            "app.bsky.actor.profile",
+            {"displayName": "Test"},
+            rkey="self",
+        )
+
+        assert result.uri == "at://did:plc:test123/app.bsky.actor.profile/self"
+        call_args = mock_client.com.atproto.repo.create_record.call_args[0][0]
+        assert call_args["rkey"] == "self"
+
+    async def test_create_without_auth_fails(
+        self, mock_client_no_auth: AsyncClient
+    ) -> None:
+        """test create fails without authentication."""
+        with pytest.raises(ValueError, match="not authenticated"):
+            await create_record(
+                mock_client_no_auth,
+                "app.bsky.feed.post",
+                {"text": "hello"},
+            )
+
+    async def test_create_preserves_existing_type_and_created_at(
+        self, mock_client: AsyncClient
+    ) -> None:
+        """test that existing $type and createdAt are not overwritten."""
+        mock_client.com.atproto.repo.create_record = AsyncMock(  # type: ignore[attr-defined]
+            return_value=models.ComAtprotoRepoCreateRecord.Response(
+                uri="at://did:plc:test123/app.bsky.feed.post/abc123",
+                cid="testcid",
+            )
+        )
+
+        record = {
+            "text": "hello",
+            "$type": "custom.type",
+            "createdAt": "2025-01-01T00:00:00Z",
+        }
+        await create_record(mock_client, "app.bsky.feed.post", record)
+
+        call_args = mock_client.com.atproto.repo.create_record.call_args[0][0]
+        assert call_args["record"]["$type"] == "custom.type"
+        assert call_args["record"]["createdAt"] == "2025-01-01T00:00:00Z"
 
 
 class TestDescribeRepo:


### PR DESCRIPTION
## Summary

- Adds optional `rkey` parameter to `create_record` across all three interfaces (SDK, CLI, MCP), enabling lexicons that require fixed record keys (e.g. `app.bsky.actor.profile/self`, `parts.page.mention.config/self`)
- Supports per-record `rkey` in batch JSONL stdin input (popped from each JSON line, like `uri` in update JSONL)
- Adds `TestCreateRecord` test class — `create_record` was previously the only operation without test coverage

Closes #79, closes #67

## Test plan

- [x] All 137 existing tests pass
- [x] New tests: basic create, create with rkey, unauthenticated failure, `$type`/`createdAt` preservation
- [x] New test: JSONL stdin with `rkey` field extraction
- [ ] Manual: `pdsx create app.bsky.actor.profile --rkey self displayName='Test'`
- [ ] Manual: `echo '{"rkey":"self","displayName":"Test"}' | pdsx create app.bsky.actor.profile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)