### PR TITLE
fix: respect `--pds` flag when `-r` is used

### DIFF
--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -429,8 +429,11 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
                 required=True,
             )
         else:
-            # for unauthenticated reads, auto-discover PDS
-            if args.repo:
+            if args.pds:
+                # prefer explicit --pds flag if provided
+                pds_url = args.pds
+            elif args.repo:
+                # for unauthenticated reads, auto-discover PDS
                 pds_url = await discover_pds(args.repo)
             elif is_get_with_full_uri:
                 # extract DID from at://did/collection/rkey


### PR DESCRIPTION
Previously, `pdsx` would always discover the PDS for unauthenticated reads. Now, it will respect the `--pds` flag whenever it is provided. This allows `pdsx` to support querying a locally running PDS instance, rather than relying on the global network.

DISCLAIMER: I'm not super familiar with Python and this was mostly generated with Gemini (though it's trivially simple). I did try to add a test, but couldn't find a satisfying way to run this code without mocking a bunch of junk and directly executing `main`, which didn't feel right. The rest of this `main` function doesn't appear to be tested, so this doesn't feel like it's making things worse at least.