### PR TITLE
feat: read-only XRPC query tool

### DIFF
--- a/docs/api-reference/pdsx-_internal-operations.mdx
+++ b/docs/api-reference/pdsx-_internal-operations.mdx
@@ -10,7 +10,45 @@ atproto record operations.
 
 ## Functions
 
-### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L22" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_normalize_query_params` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+_normalize_query_params(params: dict[str, Any]) -> dict[str, Any]
+```
+
+
+coerce values into XRPC-friendly query params.
+
+XRPC expects lowercase booleans ('true'/'false'); httpx would otherwise
+render Python bools as 'True'/'False'.
+
+
+### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+query(nsid: str, base_url: str, params: dict[str, Any] | None = None, timeout: float = 10.0) -> dict[str, Any]
+```
+
+
+issue a read-only XRPC *query* (HTTP GET) against base_url.
+
+GET-only and unauthenticated by construction: it sends no credentials and
+only ever issues a GET, so it can never invoke a procedure (writes are
+POST) or act with anyone's identity. Redirects are not followed, so the
+SSRF host check cannot be bypassed by a redirect to a private address.
+
+**Args:**
+- `nsid`: query method NSID, e.g. 'com.atproto.sync.listRepos'
+- `base_url`: service base URL, e.g. 'https\://pds.zat.dev'
+- `params`: query parameters (booleans normalized to 'true'/'false')
+- `timeout`: request timeout in seconds
+
+**Returns:**
+- the method's JSON response; non-object responses are wrapped as
+- {'result': &lt;value&gt;}
+
+
+### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L72" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_records(client: AsyncClient, collection: str, limit: int, repo: str | None = None, cursor: str | None = None) -> models.ComAtprotoRepoListRecords.Response
@@ -30,7 +68,7 @@ list records in a collection.
 - response with records and optional cursor for next page
 
 
-### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L107" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_record(client: AsyncClient, uri: str, repo: str | None = None) -> models.ComAtprotoRepoGetRecord.Response
@@ -48,7 +86,7 @@ get a specific record.
 - record response
 
 
-### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L150" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_record(client: AsyncClient, collection: str, record: dict[str, RecordValue], rkey: str | None = None) -> models.ComAtprotoRepoCreateRecord.Response
@@ -67,7 +105,7 @@ create a new record.
 - created record response
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L140" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L190" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(client: AsyncClient, uri: str, updates: dict[str, RecordValue]) -> models.ComAtprotoRepoPutRecord.Response
@@ -85,7 +123,7 @@ update an existing record.
 - updated record response
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L184" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L234" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(client: AsyncClient, uri: str) -> None
@@ -99,7 +137,7 @@ delete a record.
 - `uri`: record AT-URI (can be shorthand like 'collection/rkey' if authenticated)
 
 
-### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L205" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L255" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 describe_repo(client: AsyncClient, repo: str) -> models.ComAtprotoRepoDescribeRepo.Response
@@ -116,7 +154,7 @@ describe a repo, listing its collections.
 - response with handle, did, didDoc, collections, handleIsCorrect
 
 
-### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L221" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L271" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 upload_blob(client: AsyncClient, file_path: str | Path) -> models.ComAtprotoRepoUploadBlob.Response

--- a/docs/api-reference/pdsx-_internal-resolution.mdx
+++ b/docs/api-reference/pdsx-_internal-resolution.mdx
@@ -10,7 +10,34 @@ PDS and URI resolution utilities.
 
 ## Functions
 
-### `discover_pds` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L49" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `normalize_service_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L13" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+normalize_service_url(host: str) -> str
+```
+
+
+coerce a bare host into an https base URL.
+
+'pds.zat.dev' -> 'https://pds.zat.dev'; an explicit scheme is left as-is.
+
+
+### `reject_private_host` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+reject_private_host(base_url: str) -> None
+```
+
+
+raise ValueError if base_url targets a non-public address.
+
+Best-effort SSRF guard for read queries against arbitrary hosts: resolves
+the host and refuses loopback, private, link-local, or otherwise non-global
+addresses (e.g. cloud metadata at 169.254.169.254). This does not defend
+against DNS rebinding, so callers must not follow redirects.
+
+
+### `discover_pds` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L87" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 discover_pds(repo: str) -> str
@@ -31,7 +58,7 @@ discover PDS URL from handle or DID.
 
 ## Classes
 
-### `URIParts` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L11" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `URIParts` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L49" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 parsed components of an AT-URI.
@@ -39,7 +66,7 @@ parsed components of an AT-URI.
 
 **Methods:**
 
-#### `from_uri` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L19" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `from_uri` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/resolution.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 from_uri(cls, uri: str, client_did: str | None = None) -> URIParts

--- a/docs/api-reference/pdsx-mcp-server.mdx
+++ b/docs/api-reference/pdsx-mcp-server.mdx
@@ -10,7 +10,7 @@ pdsx MCP server implementation using fastmcp.
 
 ## Functions
 
-### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L51" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L61" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _clean_value(value: Any) -> dict[str, Any]
@@ -26,7 +26,7 @@ removes:
 - verbose reply structure (keeps just uris)
 
 
-### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L121" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L131" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _truncate_list_response(records: list[RecordResponse], total_fetched: int, has_more: bool) -> list[RecordResponse] | dict[str, Any]
@@ -38,7 +38,20 @@ truncate list response if it exceeds size limits.
 returns either the original list or a dict with truncated results and a message.
 
 
-### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L164" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_truncate_query_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L168" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+_truncate_query_response(result: dict[str, Any]) -> dict[str, Any]
+```
+
+
+trim an oversized query response so it doesn't flood the client context.
+
+trims the largest list-valued field (e.g. listRepos' 'repos') until the
+serialized response fits, and annotates what was dropped.
+
+
+### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L212" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 usage_guide() -> str
@@ -48,7 +61,7 @@ usage_guide() -> str
 instructions for using pdsx MCP tools.
 
 
-### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L199" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L259" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_post_guide() -> str
@@ -58,7 +71,7 @@ create_post_guide() -> str
 instructions for creating posts.
 
 
-### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L254" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L314" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_records(collection: str, limit: int = 10, repo: str | None = None, cursor: str | None = None) -> list[RecordResponse] | dict[str, Any]
@@ -81,7 +94,7 @@ examples:
 - list of records with uri, cid, and value fields
 
 
-### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L304" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L364" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 describe_repo(repo: str) -> RepoDescriptionResponse
@@ -103,7 +116,7 @@ examples:
 - dict with handle, did, collections, and handleIsCorrect
 
 
-### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L335" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L395" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_record(uri: str, repo: str | None = None) -> RecordResponse
@@ -124,7 +137,47 @@ examples:
 - record with uri, cid, and value fields
 
 
-### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L379" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L439" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+query(nsid: str, params: dict[str, Any] | None = None, host: str | None = None, repo: str | None = None) -> dict[str, Any]
+```
+
+
+call a read-only XRPC *query* method (HTTP GET).
+
+this is the read counterpart the record tools don't cover — sync, identity,
+server, and app.bsky.*.get* methods. it is GET-only and unauthenticated: it
+cannot create, update, delete, post, or act as you. use create/update/delete
+for writes (those require auth).
+
+**Examples:**
+
+
+
+- query("com.atproto.sync.listRepos", host="pds.zat.dev")
+    -> who is hosted on a PDS
+- query("com.atproto.identity.resolveHandle", params={"handle": "bufo.uk"})
+    -> resolve a handle to a DID
+- query("app.bsky.actor.getProfile", params={"actor": "phi.zzstoatzz.io"})
+    -> a user's public profile
+
+targeting (choose at most one):
+    repo: a handle or DID — routes to that user's PDS (for sync.*/repo.* host queries)
+    host: an explicit service base URL or bare host, e.g. "pds.zat.dev"
+    neither: defaults to the public appview, for app.bsky.* getters
+
+**Args:**
+- `nsid`: the query method, e.g. "com.atproto.sync.listRepos"
+- `params`: query parameters for the method
+- `host`: service to target (bare host gets https\://)
+- `repo`: handle or DID whose PDS to target
+
+**Returns:**
+- the method's JSON response (large list fields are trimmed; paginate with cursor)
+
+
+### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L489" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_record(collection: str, record: dict[str, Any], rkey: str | None = None) -> CreateResponse
@@ -143,7 +196,7 @@ create a new record. requires authentication.
 - dict with uri and cid of created record
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L404" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L514" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(uri: str, updates: dict[str, Any]) -> UpdateResponse
@@ -162,7 +215,7 @@ fetches the current record, merges your updates, and puts it back.
 - dict with uri and cid of updated record
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L428" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L538" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(uri: str) -> DeleteResponse
@@ -182,7 +235,7 @@ examples:
 - confirmation with deleted uri
 
 
-### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L454" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L564" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 whoami() -> IdentityResponse
@@ -198,7 +251,7 @@ requires authentication via x-atproto-handle and x-atproto-password headers.
 - dict with handle and did of authenticated user
 
 
-### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L478" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L588" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 me_resource() -> str
@@ -208,7 +261,7 @@ me_resource() -> str
 current authenticated user identity.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L494" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L604" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 
 dependencies = [
     "atproto>=0.0.63",
+    "httpx>=0.27",
     "pydantic-settings>=2.7.0",
     "pyyaml>=6.0.3",
     "rich>=13.0.0",

--- a/src/pdsx/_internal/operations.py
+++ b/src/pdsx/_internal/operations.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import httpx
 
 if sys.version_info >= (3, 11):
     from datetime import UTC
@@ -15,8 +17,56 @@ else:
 if TYPE_CHECKING:
     from atproto import AsyncClient, models
 
-from pdsx._internal.resolution import URIParts
+from pdsx._internal.resolution import URIParts, reject_private_host
 from pdsx._internal.types import RecordValue
+
+
+def _normalize_query_params(params: dict[str, Any]) -> dict[str, Any]:
+    """coerce values into XRPC-friendly query params.
+
+    XRPC expects lowercase booleans ('true'/'false'); httpx would otherwise
+    render Python bools as 'True'/'False'.
+    """
+    normalized: dict[str, Any] = {}
+    for key, value in params.items():
+        normalized[key] = (
+            ("true" if value else "false") if isinstance(value, bool) else value
+        )
+    return normalized
+
+
+async def query(
+    nsid: str,
+    base_url: str,
+    params: dict[str, Any] | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """issue a read-only XRPC *query* (HTTP GET) against base_url.
+
+    GET-only and unauthenticated by construction: it sends no credentials and
+    only ever issues a GET, so it can never invoke a procedure (writes are
+    POST) or act with anyone's identity. Redirects are not followed, so the
+    SSRF host check cannot be bypassed by a redirect to a private address.
+
+    Args:
+        nsid: query method NSID, e.g. 'com.atproto.sync.listRepos'
+        base_url: service base URL, e.g. 'https://pds.zat.dev'
+        params: query parameters (booleans normalized to 'true'/'false')
+        timeout: request timeout in seconds
+
+    Returns:
+        the method's JSON response; non-object responses are wrapped as
+        {'result': <value>}
+    """
+    reject_private_host(base_url)
+
+    url = f"{base_url.rstrip('/')}/xrpc/{nsid}"
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+        response = await client.get(url, params=_normalize_query_params(params or {}))
+        response.raise_for_status()
+        data = response.json()
+
+    return data if isinstance(data, dict) else {"result": data}
 
 
 async def list_records(

--- a/src/pdsx/_internal/resolution.py
+++ b/src/pdsx/_internal/resolution.py
@@ -2,9 +2,47 @@
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from atproto_identity.resolver import AsyncIdResolver
+
+
+def normalize_service_url(host: str) -> str:
+    """coerce a bare host into an https base URL.
+
+    'pds.zat.dev' -> 'https://pds.zat.dev'; an explicit scheme is left as-is.
+    """
+    if host.startswith(("http://", "https://")):
+        return host
+    return f"https://{host}"
+
+
+def reject_private_host(base_url: str) -> None:
+    """raise ValueError if base_url targets a non-public address.
+
+    Best-effort SSRF guard for read queries against arbitrary hosts: resolves
+    the host and refuses loopback, private, link-local, or otherwise non-global
+    addresses (e.g. cloud metadata at 169.254.169.254). This does not defend
+    against DNS rebinding, so callers must not follow redirects.
+    """
+    host = urlparse(base_url).hostname
+    if not host:
+        raise ValueError(f"could not parse host from url: {base_url!r}")
+
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise ValueError(f"could not resolve host {host!r}: {e}") from e
+
+    for *_, sockaddr in infos:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not ip.is_global:
+            raise ValueError(
+                f"refusing to query non-public host {host!r} (resolves to {ip})"
+            )
 
 
 @dataclass

--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -21,9 +21,16 @@ from pdsx._internal.operations import (
     list_records as _list_records,
 )
 from pdsx._internal.operations import (
+    query as _query,
+)
+from pdsx._internal.operations import (
     update_record as _update_record,
 )
-from pdsx._internal.resolution import URIParts
+from pdsx._internal.resolution import (
+    URIParts,
+    discover_pds,
+    normalize_service_url,
+)
 from pdsx.mcp._types import (
     CreateResponse,
     DeleteResponse,
@@ -42,6 +49,9 @@ from pdsx.mcp.middleware import AtprotoAuthMiddleware
 # response size limits to prevent context flooding in LLM clients
 MAX_LIMIT = 25  # max records per request (can paginate for more)
 MAX_RESPONSE_CHARS = 30000  # truncate responses larger than this
+
+# default target for app.bsky.* read queries that aren't tied to a single PDS
+PUBLIC_APPVIEW = "https://public.api.bsky.app"
 
 mcp = FastMCP("pdsx")
 
@@ -155,6 +165,44 @@ def _truncate_list_response(
     }
 
 
+def _truncate_query_response(result: dict[str, Any]) -> dict[str, Any]:
+    """trim an oversized query response so it doesn't flood the client context.
+
+    trims the largest list-valued field (e.g. listRepos' 'repos') until the
+    serialized response fits, and annotates what was dropped.
+    """
+    try:
+        if len(json.dumps(result, default=str)) <= MAX_RESPONSE_CHARS:
+            return result
+    except (TypeError, ValueError):
+        return result
+
+    list_keys = [k for k, v in result.items() if isinstance(v, list)]
+    if not list_keys:
+        return {
+            "truncated": True,
+            "message": f"response exceeded {MAX_RESPONSE_CHARS} chars",
+        }
+
+    key = max(list_keys, key=lambda k: len(result[k]))
+    original_len = len(result[key])
+    items = list(result[key])
+    trimmed = dict(result)
+    while (
+        items
+        and len(json.dumps({**trimmed, key: items}, default=str)) > MAX_RESPONSE_CHARS
+    ):
+        items = items[:-1]
+
+    trimmed[key] = items
+    trimmed["truncated"] = True
+    trimmed["message"] = (
+        f"trimmed '{key}' to {len(items)} of {original_len} items "
+        f"(response exceeded {MAX_RESPONSE_CHARS} chars; paginate with cursor)"
+    )
+    return trimmed
+
+
 # -----------------------------------------------------------------------------
 # prompts
 # -----------------------------------------------------------------------------
@@ -172,6 +220,18 @@ pdsx provides tools for atproto record operations (bluesky, etc).
 
 - **read operations**: no auth needed, just pass `repo` parameter
 - **write operations** (create, update, delete): require auth
+
+## read-only queries (sync, identity, server, app.bsky getters)
+
+for read methods that aren't record CRUD, use `query` — GET-only and
+unauthenticated, so it can never write or act as you:
+
+- `query("com.atproto.sync.listRepos", host="pds.zat.dev")` — who's on a PDS
+- `query("com.atproto.identity.resolveHandle", params={"handle": "alice.bsky.social"})`
+- `query("app.bsky.actor.getProfile", params={"actor": "alice.bsky.social"})`
+
+target a specific user's PDS with `repo=`, a specific host with `host=`, or
+neither (defaults to the public appview for `app.bsky.*` getters).
 
 to authenticate for writes, set these headers when configuring the MCP server:
 - `x-atproto-handle`: your atproto handle (e.g., 'you.bsky.social')
@@ -373,6 +433,56 @@ async def get_record(
         return RecordResponse(
             uri=response.uri, cid=response.cid, value=_clean_value(response.value)
         )
+
+
+@mcp.tool
+async def query(
+    nsid: str,
+    params: dict[str, Any] | None = None,
+    host: str | None = None,
+    repo: str | None = None,
+) -> dict[str, Any]:
+    """call a read-only XRPC *query* method (HTTP GET).
+
+    this is the read counterpart the record tools don't cover — sync, identity,
+    server, and app.bsky.*.get* methods. it is GET-only and unauthenticated: it
+    cannot create, update, delete, post, or act as you. use create/update/delete
+    for writes (those require auth).
+
+    examples:
+    - query("com.atproto.sync.listRepos", host="pds.zat.dev")
+        -> who is hosted on a PDS
+    - query("com.atproto.identity.resolveHandle", params={"handle": "bufo.uk"})
+        -> resolve a handle to a DID
+    - query("app.bsky.actor.getProfile", params={"actor": "phi.zzstoatzz.io"})
+        -> a user's public profile
+
+    targeting (choose at most one):
+        repo: a handle or DID — routes to that user's PDS (for sync.*/repo.* host queries)
+        host: an explicit service base URL or bare host, e.g. "pds.zat.dev"
+        neither: defaults to the public appview, for app.bsky.* getters
+
+    args:
+        nsid: the query method, e.g. "com.atproto.sync.listRepos"
+        params: query parameters for the method
+        host: service to target (bare host gets https://)
+        repo: handle or DID whose PDS to target
+
+    returns:
+        the method's JSON response (large list fields are trimmed; paginate with cursor)
+    """
+    if repo and host:
+        raise ValueError("pass either 'repo' or 'host', not both")
+
+    if repo:
+        base_url = await discover_pds(repo)
+    elif host:
+        base_url = normalize_service_url(host)
+    else:
+        base_url = PUBLIC_APPVIEW
+
+    result = await _query(nsid, base_url, params)
+    return _truncate_query_response(result)
 
 
 @mcp.tool

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,196 @@
+"""tests for the read-only XRPC `query` tool and its guards."""
+
+from typing import ClassVar
+
+import pytest
+
+from pdsx._internal.operations import _normalize_query_params, query
+from pdsx._internal.resolution import normalize_service_url, reject_private_host
+from pdsx.mcp import server
+
+# -----------------------------------------------------------------------------
+# SSRF guard
+# -----------------------------------------------------------------------------
+
+
+class TestRejectPrivateHost:
+    """reject_private_host refuses non-public targets (IP literals, no DNS)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1",
+            "https://10.0.0.1",
+            "http://192.168.1.1",
+            "https://169.254.169.254",  # cloud metadata endpoint
+            "http://[::1]",
+        ],
+    )
+    def test_blocks_non_public(self, url):
+        with pytest.raises(ValueError):
+            reject_private_host(url)
+
+    def test_allows_public_literal(self):
+        # 8.8.8.8 is globally routable; should not raise
+        reject_private_host("https://8.8.8.8")
+
+    def test_missing_host(self):
+        with pytest.raises(ValueError):
+            reject_private_host("not-a-url")
+
+
+# -----------------------------------------------------------------------------
+# pure helpers
+# -----------------------------------------------------------------------------
+
+
+def test_normalize_service_url():
+    assert normalize_service_url("pds.zat.dev") == "https://pds.zat.dev"
+    assert normalize_service_url("https://pds.zat.dev") == "https://pds.zat.dev"
+    assert normalize_service_url("http://localhost:3000") == "http://localhost:3000"
+
+
+def test_normalize_query_params_lowercases_bools():
+    assert _normalize_query_params({"a": True, "b": False, "c": 5, "d": "x"}) == {
+        "a": "true",
+        "b": "false",
+        "c": 5,
+        "d": "x",
+    }
+
+
+def test_truncate_query_response_trims_largest_list():
+    big = {
+        "repos": [{"did": "did:plc:" + "x" * 100} for _ in range(2000)],
+        "cursor": "c",
+    }
+    out = server._truncate_query_response(big)
+    assert out["truncated"] is True
+    assert len(out["repos"]) < 2000
+    assert out["cursor"] == "c"  # non-list fields preserved
+
+
+def test_truncate_query_response_passthrough_small():
+    small = {"did": "did:plc:abc", "handle": "alice.test"}
+    assert server._truncate_query_response(small) == small
+
+
+# -----------------------------------------------------------------------------
+# query operation: GET-only, unauthenticated
+# -----------------------------------------------------------------------------
+
+
+class _RecordingResponse:
+    def __init__(self, data: dict):
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._data
+
+
+class _RecordingClient:
+    """fake httpx.AsyncClient that records calls and refuses to POST."""
+
+    instances: ClassVar[list["_RecordingClient"]] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls: list = []
+        self.response = _RecordingResponse(
+            {
+                "repos": [
+                    {"did": "did:plc:b64lsctzqnzpv6vd4ry3qktw"},
+                    {"did": "did:plc:siv7zbedip4vcet4v67piibr"},
+                ]
+            }
+        )
+        _RecordingClient.instances.append(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, params=None):
+        self.calls.append(("GET", url, params))
+        return self.response
+
+    async def post(self, *args, **kwargs):  # pragma: no cover - must never run
+        self.calls.append(("POST", args, kwargs))
+        raise AssertionError("query must never issue a POST")
+
+
+@pytest.fixture
+def recording_client(monkeypatch):
+    # skip the live SSRF DNS check; we're not making real requests
+    monkeypatch.setattr(
+        "pdsx._internal.operations.reject_private_host", lambda url: None
+    )
+    _RecordingClient.instances.clear()
+    monkeypatch.setattr("pdsx._internal.operations.httpx.AsyncClient", _RecordingClient)
+    return _RecordingClient
+
+
+async def test_query_is_get_only_and_enumerates_repos(recording_client):
+    result = await query("com.atproto.sync.listRepos", "https://pds.zat.dev")
+
+    client = recording_client.instances[-1]
+    # GET-only: exactly one GET to the xrpc path, never a POST
+    assert client.calls == [
+        ("GET", "https://pds.zat.dev/xrpc/com.atproto.sync.listRepos", {}),
+    ]
+    # redirects disabled so the SSRF guard can't be bypassed by a redirect
+    assert client.kwargs.get("follow_redirects") is False
+    # both residents enumerated (the bug was finding only one)
+    assert [r["did"] for r in result["repos"]] == [
+        "did:plc:b64lsctzqnzpv6vd4ry3qktw",
+        "did:plc:siv7zbedip4vcet4v67piibr",
+    ]
+
+
+async def test_query_normalizes_bool_params(recording_client):
+    await query(
+        "app.bsky.feed.getAuthorFeed",
+        "https://x.test",
+        params={"reverse": True, "limit": 5},
+    )
+    _, _, sent = recording_client.instances[-1].calls[0]
+    assert sent == {"reverse": "true", "limit": 5}
+
+
+# -----------------------------------------------------------------------------
+# query tool glue: target selection
+# -----------------------------------------------------------------------------
+
+
+async def test_query_tool_rejects_repo_and_host():
+    with pytest.raises(ValueError):
+        await server.query.fn(nsid="com.atproto.sync.listRepos", repo="a", host="b")
+
+
+async def test_query_tool_selects_base_url(monkeypatch):
+    captured: list = []
+
+    async def fake_query(nsid, base_url, params=None):
+        captured.append(base_url)
+        return {"ok": True}
+
+    async def fake_discover(repo):
+        return "https://pds.example"
+
+    monkeypatch.setattr(server, "_query", fake_query)
+    monkeypatch.setattr(server, "discover_pds", fake_discover)
+
+    await server.query.fn(nsid="com.atproto.sync.listRepos", host="pds.zat.dev")
+    await server.query.fn(nsid="app.bsky.actor.getProfile", params={"actor": "a"})
+    await server.query.fn(nsid="com.atproto.repo.describeRepo", repo="alice.test")
+
+    assert captured == [
+        "https://pds.zat.dev",
+        server.PUBLIC_APPVIEW,
+        "https://pds.example",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -754,6 +754,7 @@ name = "pdsx"
 source = { editable = "." }
 dependencies = [
     { name = "atproto" },
+    { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -783,6 +784,7 @@ dev = [
 requires-dist = [
     { name = "atproto", specifier = ">=0.0.63" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "jmespath", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
Adds a `query` MCP tool for the read-only XRPC surface pdsx didn't cover. pdsx's read tools only did **record** CRUD (`list_records`/`get_record`/`describe_repo`); the non-record query methods — `com.atproto.sync.*`, `com.atproto.identity.*`, `com.atproto.server.describeServer`, the `app.bsky.*.get*` family — had no path. That gap is why an agent on pdsx can't answer something as basic as *"who is hosted on this PDS"*.

Safe by construction: `query` is **GET-only and unauthenticated**, so it can never write or act as you. No new generic *authenticated* invoke — writes stay on the existing typed, auth-gated `create`/`update`/`delete`.

```
query("com.atproto.sync.listRepos", host="pds.zat.dev")        # who's on a PDS
query("com.atproto.identity.resolveHandle", params={"handle": "bufo.uk"})
query("app.bsky.actor.getProfile", params={"actor": "phi.zzstoatzz.io"})
```

<details>
<summary>why it's safe (the design)</summary>

- **a query is a GET; a procedure is a POST.** the tool only ever issues GET, so it is structurally incapable of mutation — no NSID allowlist to maintain.
- **no credentials.** even if the GET-only invariant regressed, there's no session to write with. reuses pdsx's existing "reads need no auth" model.
- **redirects disabled** (`follow_redirects=False`) so the host guard can't be bypassed by a redirect to a private address.
- **SSRF guard** (`reject_private_host`): resolves the target and refuses loopback / private / link-local / cloud-metadata addresses.
- **targeting:** `repo=` routes to that user's PDS (reuses `discover_pds`), `host=` targets a service (bare host gets `https://`), neither defaults to the public appview for `app.bsky.*` getters.
- oversized responses trim their largest list field (paginate with cursor).
</details>

<details>
<summary>tests & verification</summary>

`tests/test_query.py` (mocked, offline, matching repo convention):
- SSRF guard blocks `127.0.0.1` / `10.x` / `192.168.x` / `169.254.169.254` / `::1`; allows a global literal
- `query` issues exactly one GET to `/xrpc/{nsid}` and **never** POSTs; `follow_redirects=False`
- enumerates both repos from a `listRepos` response (the original bug found only one)
- bool params normalized to `true`/`false`; tool rejects `repo`+`host` together; base-URL selection

Live (real network, no mocks):
```
listRepos @ pds.zat.dev -> 2 repos
  did:plc:b64lsctzqnzpv6vd4ry3qktw -> @bufo.uk
  did:plc:siv7zbedip4vcet4v67piibr -> @waow.tech
SSRF guard: refusing to query non-public host '169.254.169.254'
```

Full suite: 152 passed; ruff + ty + prek clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)