### PR TITLE
fix(mcp): handle sync OR async fastmcp Context.get_state/set_state

### DIFF
--- a/docs/api-reference/pdsx-mcp-client.mdx
+++ b/docs/api-reference/pdsx-mcp-client.mdx
@@ -10,7 +10,22 @@ helper for creating atproto clients with per-request credentials.
 
 ## Functions
 
-### `_get_credentials_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_maybe_await` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+_maybe_await(value: Any) -> Any
+```
+
+
+await ``value`` if it's awaitable, else return it as-is.
+
+fastmcp's ``Context.get_state`` / ``set_state`` are sync in 2.x and
+coroutines in 3.x (see #85). hosted runtimes (e.g. FastMCP Cloud) may pin
+a different fastmcp than our dependency, so we can't assume either — detect
+at call time instead of relying on the installed version.
+
+
+### `_get_credentials_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L30" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _get_credentials_from_context() -> CredentialsContext
@@ -23,7 +38,7 @@ extract credentials from fastmcp context if available.
 - credentials dict with handle, password, pds_url, repo (any may be None)
 
 
-### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L79" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L93" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_atproto_client(require_auth: bool = False, operation: str = 'this operation', target_repo: str | None = None) -> AsyncIterator[AsyncClient]
@@ -53,7 +68,7 @@ this enables both:
 - `AuthenticationRequired`: if require_auth=True and no credentials available
 
 
-### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L166" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L180" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_repo_from_context() -> str | None
@@ -63,7 +78,7 @@ get_repo_from_context() -> str | None
 get repo override from context if set via x-atproto-repo header.
 
 
-### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L175" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L189" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 resolve_pds_url() -> str
@@ -82,7 +97,7 @@ to the AppView.
 
 ## Classes
 
-### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L71" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 raised when an operation requires authentication but none was provided.
@@ -90,7 +105,7 @@ raised when an operation requires authentication but none was provided.
 
 **Methods:**
 
-#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L74" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 __init__(self, operation: str = 'this operation')

--- a/docs/api-reference/pdsx-mcp-middleware.mdx
+++ b/docs/api-reference/pdsx-mcp-middleware.mdx
@@ -10,7 +10,7 @@ middleware for pdsx MCP server.
 
 ## Classes
 
-### `AtprotoAuthMiddleware` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L15" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `AtprotoAuthMiddleware` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 extract atproto credentials from http headers with fallback to environment.
@@ -25,7 +25,7 @@ accessed using `get_atproto_client()` from the client module.
 
 **Methods:**
 
-#### `_extract_credentials` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L32" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `_extract_credentials` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L34" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _extract_credentials(self) -> None
@@ -34,7 +34,7 @@ _extract_credentials(self) -> None
 extract credentials from http headers into fastmcp context.
 
 
-#### `on_call_tool` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L68" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `on_call_tool` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L71" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 on_call_tool(self, context: MiddlewareContext[mt.CallToolRequestParams], call_next: CallNext[mt.CallToolRequestParams, Any]) -> Any
@@ -43,7 +43,7 @@ on_call_tool(self, context: MiddlewareContext[mt.CallToolRequestParams], call_ne
 extract credentials from headers on each tool call.
 
 
-#### `on_read_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `on_read_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/middleware.py#L80" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 on_read_resource(self, context: MiddlewareContext[mt.ReadResourceRequestParams], call_next: CallNext[mt.ReadResourceRequestParams, Sequence[ReadResourceContents]]) -> Sequence[ReadResourceContents]

--- a/src/pdsx/mcp/client.py
+++ b/src/pdsx/mcp/client.py
@@ -1,15 +1,30 @@
 """helper for creating atproto clients with per-request credentials."""
 
+import inspect
 import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from atproto import AsyncClient
 
 from pdsx.mcp._types import CredentialsContext
 
 logger = logging.getLogger(__name__)
+
+
+async def _maybe_await(value: Any) -> Any:
+    """await ``value`` if it's awaitable, else return it as-is.
+
+    fastmcp's ``Context.get_state`` / ``set_state`` are sync in 2.x and
+    coroutines in 3.x (see #85). hosted runtimes (e.g. FastMCP Cloud) may pin
+    a different fastmcp than our dependency, so we can't assume either — detect
+    at call time instead of relying on the installed version.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 async def _get_credentials_from_context() -> CredentialsContext:
@@ -29,11 +44,10 @@ async def _get_credentials_from_context() -> CredentialsContext:
         from fastmcp.server.dependencies import get_context
 
         ctx = get_context()
-        # fastmcp 3.x made get_state a coroutine; await it (see #85)
-        result["handle"] = await ctx.get_state("atproto_handle")
-        result["password"] = await ctx.get_state("atproto_password")
-        result["pds_url"] = await ctx.get_state("atproto_pds_url")
-        result["repo"] = await ctx.get_state("atproto_repo")
+        result["handle"] = await _maybe_await(ctx.get_state("atproto_handle"))
+        result["password"] = await _maybe_await(ctx.get_state("atproto_password"))
+        result["pds_url"] = await _maybe_await(ctx.get_state("atproto_pds_url"))
+        result["repo"] = await _maybe_await(ctx.get_state("atproto_repo"))
     except RuntimeError as e:
         if "No active context found" not in str(e):
             raise

--- a/src/pdsx/mcp/middleware.py
+++ b/src/pdsx/mcp/middleware.py
@@ -9,6 +9,8 @@ from fastmcp.server.dependencies import get_http_headers
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 
+from pdsx.mcp.client import _maybe_await
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,22 +50,23 @@ class AtprotoAuthMiddleware(Middleware):
         pds_url = headers.get("x-atproto-pds-url")
         repo = headers.get("x-atproto-repo")
 
-        # fastmcp 3.x made set_state a coroutine; await it (see #85)
+        # set_state is sync in fastmcp 2.x, a coroutine in 3.x (see #85);
+        # _maybe_await handles either so this works across runtimes
         if handle:
             logger.debug("extracted atproto handle from http headers")
-            await fastmcp_ctx.set_state("atproto_handle", handle)
+            await _maybe_await(fastmcp_ctx.set_state("atproto_handle", handle))
 
         if password:
             logger.debug("extracted atproto password from http headers")
-            await fastmcp_ctx.set_state("atproto_password", password)
+            await _maybe_await(fastmcp_ctx.set_state("atproto_password", password))
 
         if pds_url:
             logger.debug("extracted atproto pds url from http headers")
-            await fastmcp_ctx.set_state("atproto_pds_url", pds_url)
+            await _maybe_await(fastmcp_ctx.set_state("atproto_pds_url", pds_url))
 
         if repo:
             logger.debug("extracted atproto repo from http headers")
-            await fastmcp_ctx.set_state("atproto_repo", repo)
+            await _maybe_await(fastmcp_ctx.set_state("atproto_repo", repo))
 
     async def on_call_tool(
         self,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 from pdsx.mcp._types import (
     CreateResponse,
     CredentialsContext,
@@ -370,20 +372,45 @@ class _FakeAsyncContext:
         self._state[key] = value
 
 
-class TestAsyncStateRegression:
-    """regression tests for #85: fastmcp 3.x made Context.get_state / set_state
-    coroutines. pdsx must await them, otherwise un-awaited coroutines leak in as
-    credentials and every tool fails with
-    `'coroutine' object has no attribute 'startswith'/'endswith'`.
+class _FakeSyncContext:
+    """fastmcp 2.x-style context whose get_state/set_state are plain sync.
+
+    also matches hosted runtimes (e.g. FastMCP Cloud) that may serve a fastmcp
+    different from our pinned dependency — the reason the fix must not assume
+    either calling convention (see #85).
     """
 
-    async def test_get_credentials_awaits_get_state(self, monkeypatch):
-        """credentials resolve to plain strings, not un-awaited coroutines."""
+    def __init__(self, state: dict | None = None):
+        self._state: dict = dict(state or {})
+
+    def get_state(self, key: str):
+        return self._state.get(key)
+
+    def set_state(self, key: str, value, *, serializable: bool = True) -> None:
+        self._state[key] = value
+
+
+# both context styles must work: 3.x (async) and 2.x / hosted (sync)
+_CONTEXT_KINDS = [_FakeAsyncContext, _FakeSyncContext]
+
+
+class TestAsyncStateRegression:
+    """regression tests for #85: fastmcp made Context.get_state / set_state
+    coroutines in 3.x but they're plain sync in 2.x, and hosted runtimes may
+    pin either. pdsx must handle both — otherwise credentials come back as
+    un-awaited coroutines (`'coroutine' object has no attribute 'startswith'`)
+    or `await` blows up on a plain return value (`object NoneType can't be used
+    in 'await' expression`).
+    """
+
+    @pytest.mark.parametrize("ctx_cls", _CONTEXT_KINDS)
+    async def test_get_credentials_resolves_strings(self, monkeypatch, ctx_cls):
+        """credentials resolve to plain strings under sync OR async get_state."""
         import fastmcp.server.dependencies as deps
 
         from pdsx.mcp.client import _get_credentials_from_context
 
-        ctx = _FakeAsyncContext(
+        ctx = ctx_cls(
             {
                 "atproto_handle": "alice.bsky.social",
                 "atproto_password": "app-pw",
@@ -403,35 +430,39 @@ class TestAsyncStateRegression:
         for value in creds.values():
             assert isinstance(value, str)
 
-    async def test_get_repo_from_context_awaits(self, monkeypatch):
+    @pytest.mark.parametrize("ctx_cls", _CONTEXT_KINDS)
+    async def test_get_repo_from_context(self, monkeypatch, ctx_cls):
         """get_repo_from_context returns the resolved repo string."""
         import fastmcp.server.dependencies as deps
 
         from pdsx.mcp.client import get_repo_from_context
 
-        ctx = _FakeAsyncContext({"atproto_repo": "alice.bsky.social"})
+        ctx = ctx_cls({"atproto_repo": "alice.bsky.social"})
         monkeypatch.setattr(deps, "get_context", lambda: ctx)
 
         assert await get_repo_from_context() == "alice.bsky.social"
 
-    async def test_resolve_pds_url_awaits(self, monkeypatch):
+    @pytest.mark.parametrize("ctx_cls", _CONTEXT_KINDS)
+    async def test_resolve_pds_url(self, monkeypatch, ctx_cls):
         """resolve_pds_url returns the header pds_url, not a coroutine."""
         import fastmcp.server.dependencies as deps
 
         from pdsx.mcp.client import resolve_pds_url
 
-        ctx = _FakeAsyncContext({"atproto_pds_url": "https://pds.example"})
+        ctx = ctx_cls({"atproto_pds_url": "https://pds.example"})
         monkeypatch.setattr(deps, "get_context", lambda: ctx)
 
         assert await resolve_pds_url() == "https://pds.example"
 
-    async def test_middleware_awaits_set_state(self, monkeypatch):
-        """middleware writes header credentials into context state (awaiting set_state)."""
+    @pytest.mark.parametrize("ctx_cls", _CONTEXT_KINDS)
+    async def test_middleware_writes_state(self, monkeypatch, ctx_cls):
+        """middleware writes header credentials into context state under both
+        sync and async set_state."""
         import fastmcp.server.dependencies as deps
 
         from pdsx.mcp import middleware as mw
 
-        ctx = _FakeAsyncContext()
+        ctx = ctx_cls()
         monkeypatch.setattr(deps, "get_context", lambda: ctx)
         monkeypatch.setattr(
             mw,
@@ -445,7 +476,8 @@ class TestAsyncStateRegression:
 
         await mw.AtprotoAuthMiddleware()._extract_credentials()
 
-        # if set_state weren't awaited, state would stay empty (coroutine discarded)
+        # if set_state weren't handled, async state would stay empty (coroutine
+        # discarded) and the await would raise under sync state
         assert ctx._state["atproto_handle"] == "alice.bsky.social"
         assert ctx._state["atproto_password"] == "app-pw"
         assert ctx._state["atproto_repo"] == "alice.bsky.social"


### PR DESCRIPTION
Follow-up to #86.

#86 fixed the fastmcp-3 async `get_state`/`set_state` bug locally, but **FastMCP Cloud** (the hosted `pdsx-by-zzstoatzz.fastmcp.app` deploy) pins a fastmcp where those methods are still **sync** — so `await ctx.get_state(...)` flipped the failure mode to:

```
object NoneType can't be used in 'await' expression
```

i.e. every tool was still broken on the deployed server, just with a different error. The installed fastmcp version doesn't govern the hosted runtime, so the fix can't assume either convention.

## fix
- add `_maybe_await(value)` — awaits only if `inspect.isawaitable(value)`, else returns as-is
- route every `ctx.get_state(...)` (`client.py`) and `ctx.set_state(...)` (`middleware.py`) through it

## tests
- regression tests now parametrize over `_FakeAsyncContext` (3.x) **and** `_FakeSyncContext` (2.x / hosted). The sync variants reproduce the cloud `await None` error — verified they fail on the bare-await code and pass with `_maybe_await`.
- full suite: **166 passed**; prek (ruff / ty / mdxify) clean and idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
