### PR TITLE
fix(mcp): surface query() failures as data, not exceptions

### DIFF
--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any
 
+import httpx
 from fastmcp import FastMCP
 
 from pdsx._internal.operations import (
@@ -498,7 +499,10 @@ async def query(
             a deliberate, per-NSID decision: file an issue to add one.
 
     returns:
-        the method's JSON response (large list fields are trimmed; paginate with cursor)
+        the method's JSON response (large list fields are trimmed; paginate
+        with cursor). transport / HTTP / decode failures come back as a
+        structured ``{"error": ..., "message": ...}`` dict rather than
+        raising — so a bad host guess doesn't burn the caller's retry budget.
     """
     if repo and host:
         raise ValueError("pass either 'repo' or 'host', not both")
@@ -546,7 +550,36 @@ async def query(
     else:
         base_url = PUBLIC_APPVIEW
 
-    result = await _query(nsid, base_url, params, auth_token=auth_token)
+    try:
+        result = await _query(nsid, base_url, params, auth_token=auth_token)
+    except httpx.HTTPStatusError as exc:
+        # 4xx/5xx — return as data so the model can adapt (wrong host, bad
+        # params, etc.) instead of burning the agent's retry budget.
+        return {
+            "error": "http_status",
+            "status": exc.response.status_code,
+            "url": str(exc.request.url),
+            "message": exc.response.text[:500],
+        }
+    except httpx.RequestError as exc:
+        # DNS/connect/timeout — same reasoning: surface the failure as data.
+        return {
+            "error": "transport",
+            "url": str(exc.request.url) if exc.request else "",
+            "message": f"{type(exc).__name__}: {exc}",
+        }
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # the endpoint returned non-JSON (e.g. com.atproto.sync.getBlob returns
+        # raw blob bytes). `query` is JSON-only by contract — tell the caller
+        # they reached for the wrong tool rather than crashing.
+        return {
+            "error": "non_json_response",
+            "message": (
+                f"{nsid!r} did not return JSON ({type(exc).__name__}). "
+                "this endpoint likely returns binary or non-JSON content — "
+                "use a method-specific tool instead of `query`."
+            ),
+        }
     return _truncate_query_response(result)
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -235,6 +235,59 @@ async def test_authenticated_query_allowlist_contains_notifications():
     )
 
 
+async def test_query_tool_returns_http_error_as_data(monkeypatch):
+    """4xx/5xx come back as structured data instead of raising — a bad host
+    guess during exploration shouldn't burn the agent's retry budget."""
+    import httpx
+
+    async def fake_query(nsid, base_url, params=None, auth_token=None):
+        request = httpx.Request("GET", f"{base_url}/xrpc/{nsid}")
+        response = httpx.Response(404, request=request, content=b"not found here")
+        raise httpx.HTTPStatusError("404", request=request, response=response)
+
+    monkeypatch.setattr(server, "_query", fake_query)
+    result = await server.query(
+        nsid="com.atproto.sync.listRepos", host="grain.social"
+    )
+    assert result["error"] == "http_status"
+    assert result["status"] == 404
+    assert "grain.social" in result["url"]
+    assert "not found here" in result["message"]
+
+
+async def test_query_tool_returns_transport_error_as_data(monkeypatch):
+    """DNS / connect / timeout come back as structured data, not exceptions."""
+    import httpx
+
+    async def fake_query(nsid, base_url, params=None, auth_token=None):
+        request = httpx.Request("GET", f"{base_url}/xrpc/{nsid}")
+        raise httpx.ConnectError("nodename nor servname provided", request=request)
+
+    monkeypatch.setattr(server, "_query", fake_query)
+    result = await server.query(
+        nsid="com.atproto.sync.listRepos", host="pds.grain.social"
+    )
+    assert result["error"] == "transport"
+    assert "ConnectError" in result["message"]
+
+
+async def test_query_tool_returns_non_json_error_as_data(monkeypatch):
+    """a method that returns binary (e.g. sync.getBlob) shouldn't crash — tell
+    the caller they reached for the wrong tool."""
+    import json as _json
+
+    async def fake_query(nsid, base_url, params=None, auth_token=None):
+        raise _json.JSONDecodeError("Expecting value", "\x89PNG", 0)
+
+    monkeypatch.setattr(server, "_query", fake_query)
+    result = await server.query(
+        nsid="com.atproto.sync.getBlob", host="pds.zzstoatzz.io"
+    )
+    assert result["error"] == "non_json_response"
+    assert "com.atproto.sync.getBlob" in result["message"]
+    assert "binary" in result["message"]
+
+
 async def test_unauthenticated_query_accepts_any_nsid_monkeypatched(monkeypatch):
     """the allowlist gate must not affect the unauth path — public reads
     of any NSID are still fine."""


### PR DESCRIPTION
A failing `query` (404, DNS miss, binary response) was raising up through fastmcp into pydantic-ai's tool-call layer, where `max_retries=1` would abort the entire agent run after a single bad host guess. Exploration calls — picking the wrong PDS, hitting an endpoint that returns blob bytes — should be cheap to fail.

The MCP `query` tool now catches `httpx.HTTPStatusError`, `httpx.RequestError`, and JSON/Unicode decode errors and returns a structured `{\"error\": ..., \"message\": ...}` dict instead. The CLI/library path (`_internal.operations.query`) is unchanged — it still raises, preserving existing error flow for non-MCP callers.

## Motivating failures (live phi batch)

- `query(\"com.atproto.sync.listRepos\", host=\"grain.social\")` → 404 → retry with `pds.grain.social` → DNS miss → whole agent run aborted with \`UnexpectedModelBehavior: Tool 'query' exceeded max retries count of 1\`
- `query(\"com.atproto.sync.getBlob\", ...)` → tried to JSON-decode PNG header → \`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89\`

Both now come back as data the model can read and adapt to.

## Test plan

- [x] new tests for http_status / transport / non_json_response paths
- [x] existing 21 query tests still pass
- [x] ruff clean