### PR TITLE
fix(mcp): authenticated queries never worked — and the auth knob shouldn't exist

### DIFF
--- a/docs/api-reference/pdsx-cli.mdx
+++ b/docs/api-reference/pdsx-cli.mdx
@@ -100,7 +100,7 @@ async_main() -> int
 main entry point.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L590" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L593" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> NoReturn

--- a/docs/api-reference/pdsx-mcp-client.mdx
+++ b/docs/api-reference/pdsx-mcp-client.mdx
@@ -38,7 +38,7 @@ extract credentials from fastmcp context if available.
 - credentials dict with handle, password, pds_url, repo (any may be None)
 
 
-### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L93" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L113" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_atproto_client(require_auth: bool = False, operation: str = 'this operation', target_repo: str | None = None) -> AsyncIterator[AsyncClient]
@@ -68,7 +68,7 @@ this enables both:
 - `AuthenticationRequired`: if require_auth=True and no credentials available
 
 
-### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L180" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_repo_from_context() -> str | None
@@ -78,7 +78,7 @@ get_repo_from_context() -> str | None
 get repo override from context if set via x-atproto-repo header.
 
 
-### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L189" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L209" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 resolve_pds_url() -> str
@@ -97,7 +97,7 @@ to the AppView.
 
 ## Classes
 
-### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L105" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 raised when an operation requires authentication but none was provided.
@@ -105,7 +105,7 @@ raised when an operation requires authentication but none was provided.
 
 **Methods:**
 
-#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L88" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 __init__(self, operation: str = 'this operation')

--- a/docs/api-reference/pdsx-mcp-client.mdx
+++ b/docs/api-reference/pdsx-mcp-client.mdx
@@ -38,7 +38,7 @@ extract credentials from fastmcp context if available.
 - credentials dict with handle, password, pds_url, repo (any may be None)
 
 
-### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L113" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_atproto_client(require_auth: bool = False, operation: str = 'this operation', target_repo: str | None = None) -> AsyncIterator[AsyncClient]
@@ -68,7 +68,7 @@ this enables both:
 - `AuthenticationRequired`: if require_auth=True and no credentials available
 
 
-### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L200" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L198" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_repo_from_context() -> str | None
@@ -78,7 +78,7 @@ get_repo_from_context() -> str | None
 get repo override from context if set via x-atproto-repo header.
 
 
-### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L209" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 resolve_pds_url() -> str
@@ -97,7 +97,7 @@ to the AppView.
 
 ## Classes
 
-### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L105" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 raised when an operation requires authentication but none was provided.
@@ -105,7 +105,7 @@ raised when an operation requires authentication but none was provided.
 
 **Methods:**
 
-#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L106" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 __init__(self, operation: str = 'this operation')

--- a/docs/api-reference/pdsx-mcp-server.mdx
+++ b/docs/api-reference/pdsx-mcp-server.mdx
@@ -10,7 +10,7 @@ pdsx MCP server implementation using fastmcp.
 
 ## Functions
 
-### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L75" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_clean_value` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _clean_value(value: Any) -> dict[str, Any]
@@ -26,7 +26,7 @@ removes:
 - verbose reply structure (keeps just uris)
 
 
-### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L145" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_truncate_list_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L146" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _truncate_list_response(records: list[RecordResponse], total_fetched: int, has_more: bool) -> list[RecordResponse] | dict[str, Any]
@@ -38,7 +38,7 @@ truncate list response if it exceeds size limits.
 returns either the original list or a dict with truncated results and a message.
 
 
-### `_truncate_query_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L182" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_truncate_query_response` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L183" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _truncate_query_response(result: dict[str, Any]) -> dict[str, Any]
@@ -51,7 +51,7 @@ trims the largest list-valued field (e.g. listRepos' 'repos') until the
 serialized response fits, and annotates what was dropped.
 
 
-### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L226" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `usage_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 usage_guide() -> str
@@ -61,7 +61,7 @@ usage_guide() -> str
 instructions for using pdsx MCP tools.
 
 
-### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L273" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_post_guide` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L274" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_post_guide() -> str
@@ -71,7 +71,7 @@ create_post_guide() -> str
 instructions for creating posts.
 
 
-### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L328" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L329" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_records(collection: str, limit: int = 10, repo: str | None = None, cursor: str | None = None) -> list[RecordResponse] | dict[str, Any]
@@ -94,7 +94,7 @@ examples:
 - list of records with uri, cid, and value fields
 
 
-### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L378" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L379" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 describe_repo(repo: str) -> RepoDescriptionResponse
@@ -116,7 +116,7 @@ examples:
 - dict with handle, did, collections, and handleIsCorrect
 
 
-### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L409" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L410" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_record(uri: str, repo: str | None = None) -> RecordResponse
@@ -137,7 +137,7 @@ examples:
 - record with uri, cid, and value fields
 
 
-### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L453" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L454" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 query(nsid: str, params: dict[str, Any] | None = None, host: str | None = None, repo: str | None = None, authenticated: bool = False) -> dict[str, Any]
@@ -148,47 +148,49 @@ call a read-only XRPC *query* method (HTTP GET).
 
 this is the read counterpart the record tools don't cover — sync, identity,
 server, and the app.bsky.* getter family. it is GET-only and structurally
-cannot create, update, delete, post, or act as a procedure. by default it
-is unauthenticated; pass ``authenticated=True`` for endpoints that require
-a session (e.g., notifications, private feeds, auth-required graph getters).
+cannot create, update, delete, post, or act as a procedure.
 
-examples (unauth):
+authentication is automatic: the few NSIDs that require the caller's
+session (``AUTHENTICATED_QUERY_ALLOWLIST`` — currently notifications)
+are queried with it; everything else is queried publicly. there is no
+auth knob to get wrong — the allowlist is the whole decision.
+
+**Examples:**
+
+
+
 - query("com.atproto.sync.listRepos", host="pds.zat.dev")
     -> who is hosted on a PDS
 - query("com.atproto.identity.resolveHandle", params={"handle": "bufo.uk"})
     -> resolve a handle to a DID
 - query("app.bsky.actor.getProfile", params={"actor": "phi.zzstoatzz.io"})
     -> a user's public profile
-- query("app.bsky.feed.getQuotes", params={"uri": "at://.../post/xyz"})
-    -> who quoted a post (no auth required)
-
-examples (auth):
-- query("app.bsky.notification.listNotifications",
-        params={"limit": 30}, authenticated=True)
-    -> your own notifications
+- query("app.bsky.notification.listNotifications", params={"limit": 30})
+    -> your own notifications (session attached automatically)
 
 targeting (choose at most one):
     repo: a handle or DID — routes to that user's PDS (for sync.*/repo.* host queries)
     host: an explicit service base URL or bare host, e.g. "pds.zat.dev"
-    neither: defaults to the public appview (unauth) or your PDS (auth);
-        your PDS proxies authenticated app.bsky.* calls to the AppView.
+    neither: defaults to the public appview, or your PDS for
+        session-backed NSIDs (it proxies authenticated app.bsky.*
+        calls to the AppView).
 
 **Args:**
 - `nsid`: the query method, e.g. "com.atproto.sync.listRepos"
 - `params`: query parameters for the method
 - `host`: service to target (bare host gets https\://)
 - `repo`: handle or DID whose PDS to target
-- `authenticated`: send the caller's session token (Bearer JWT). still
-GET-only / SSRF-guarded / no-redirects — only the authority axis
-changes, and only NSIDs in ``AUTHENTICATED_QUERY_ALLOWLIST`` are
-permitted (currently notifications). extending the allowlist is
-a deliberate, per-NSID decision\: file an issue to add one.
+- `authenticated`: deprecated and ignored — auth is decided by the
+allowlist. kept so existing callers don't fail validation.
 
 **Returns:**
-- the method's JSON response (large list fields are trimmed; paginate with cursor)
+- the method's JSON response (large list fields are trimmed; paginate
+- with cursor). transport / HTTP / decode failures come back as a
+- structured ``{"error": ..., "message": ...}`` dict rather than
+- raising — so a bad host guess doesn't burn the caller's retry budget.
 
 
-### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L554" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L582" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_record(collection: str, record: dict[str, Any], rkey: str | None = None) -> CreateResponse
@@ -207,7 +209,7 @@ create a new record. requires authentication.
 - dict with uri and cid of created record
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L579" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L607" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(uri: str, updates: dict[str, Any]) -> UpdateResponse
@@ -226,7 +228,7 @@ fetches the current record, merges your updates, and puts it back.
 - dict with uri and cid of updated record
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L603" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L631" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(uri: str) -> DeleteResponse
@@ -246,7 +248,7 @@ examples:
 - confirmation with deleted uri
 
 
-### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L629" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L657" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 whoami() -> IdentityResponse
@@ -262,7 +264,7 @@ requires authentication via x-atproto-handle and x-atproto-password headers.
 - dict with handle and did of authenticated user
 
 
-### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L653" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `me_resource` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L681" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 me_resource() -> str
@@ -272,7 +274,7 @@ me_resource() -> str
 current authenticated user identity.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L669" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/server.py#L697" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> None

--- a/src/pdsx/mcp/client.py
+++ b/src/pdsx/mcp/client.py
@@ -69,9 +69,7 @@ async def _get_credentials_from_context() -> CredentialsContext:
             headers = {}
         if headers:
             result["handle"] = result["handle"] or headers.get("x-atproto-handle")
-            result["password"] = result["password"] or headers.get(
-                "x-atproto-password"
-            )
+            result["password"] = result["password"] or headers.get("x-atproto-password")
             result["pds_url"] = result["pds_url"] or headers.get("x-atproto-pds-url")
             result["repo"] = result["repo"] or headers.get("x-atproto-repo")
 

--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -462,41 +462,37 @@ async def query(
 
     this is the read counterpart the record tools don't cover — sync, identity,
     server, and the app.bsky.* getter family. it is GET-only and structurally
-    cannot create, update, delete, post, or act as a procedure. by default it
-    is unauthenticated; pass ``authenticated=True`` for endpoints that require
-    a session (e.g., notifications, private feeds, auth-required graph getters).
+    cannot create, update, delete, post, or act as a procedure.
 
-    examples (unauth):
+    authentication is automatic: the few NSIDs that require the caller's
+    session (``AUTHENTICATED_QUERY_ALLOWLIST`` — currently notifications)
+    are queried with it; everything else is queried publicly. there is no
+    auth knob to get wrong — the allowlist is the whole decision.
+
+    examples:
     - query("com.atproto.sync.listRepos", host="pds.zat.dev")
         -> who is hosted on a PDS
     - query("com.atproto.identity.resolveHandle", params={"handle": "bufo.uk"})
         -> resolve a handle to a DID
     - query("app.bsky.actor.getProfile", params={"actor": "phi.zzstoatzz.io"})
         -> a user's public profile
-    - query("app.bsky.feed.getQuotes", params={"uri": "at://.../post/xyz"})
-        -> who quoted a post (no auth required)
-
-    examples (auth):
-    - query("app.bsky.notification.listNotifications",
-            params={"limit": 30}, authenticated=True)
-        -> your own notifications
+    - query("app.bsky.notification.listNotifications", params={"limit": 30})
+        -> your own notifications (session attached automatically)
 
     targeting (choose at most one):
         repo: a handle or DID — routes to that user's PDS (for sync.*/repo.* host queries)
         host: an explicit service base URL or bare host, e.g. "pds.zat.dev"
-        neither: defaults to the public appview (unauth) or your PDS (auth);
-            your PDS proxies authenticated app.bsky.* calls to the AppView.
+        neither: defaults to the public appview, or your PDS for
+            session-backed NSIDs (it proxies authenticated app.bsky.*
+            calls to the AppView).
 
     args:
         nsid: the query method, e.g. "com.atproto.sync.listRepos"
         params: query parameters for the method
         host: service to target (bare host gets https://)
         repo: handle or DID whose PDS to target
-        authenticated: send the caller's session token (Bearer JWT). still
-            GET-only / SSRF-guarded / no-redirects — only the authority axis
-            changes, and only NSIDs in ``AUTHENTICATED_QUERY_ALLOWLIST`` are
-            permitted (currently notifications). extending the allowlist is
-            a deliberate, per-NSID decision: file an issue to add one.
+        authenticated: deprecated and ignored — auth is decided by the
+            allowlist. kept so existing callers don't fail validation.
 
     returns:
         the method's JSON response (large list fields are trimmed; paginate
@@ -509,19 +505,13 @@ async def query(
 
     auth_token: str | None = None
 
-    if authenticated:
-        # gate at the authority boundary: authenticated reads can expose
-        # private account data, so the NSID must be on the explicit allowlist.
-        # the unauth path stays open to any NSID (public data anyway).
-        if nsid not in AUTHENTICATED_QUERY_ALLOWLIST:
-            raise ValueError(
-                f"{nsid!r} is not on the authenticated-query allowlist. "
-                f"allowed: {sorted(AUTHENTICATED_QUERY_ALLOWLIST)}. file an "
-                "issue at https://github.com/zzstoatzz/pdsx if you need it "
-                "added — extending the allowlist is a deliberate decision "
-                "that the response is acceptable for an agentic caller to "
-                "read with the operator's session."
-            )
+    # the allowlist is the whole auth decision: NSIDs on it require the
+    # caller's session and can expose private account data (extending it is
+    # a deliberate, per-NSID review — file an issue). NSIDs off it are
+    # public data and are always queried without credentials, regardless of
+    # the deprecated `authenticated` flag — a caller-supplied auth knob was
+    # a degree of freedom the server already fully determines.
+    if nsid in AUTHENTICATED_QUERY_ALLOWLIST:
         # resolve the caller's session and extract the access JWT; the JWT is
         # an opaque string we then send as Bearer on the GET. the context
         # manager just yields the client — exiting it does not invalidate the
@@ -547,7 +537,7 @@ async def query(
         base_url = await discover_pds(repo)
     elif host:
         base_url = normalize_service_url(host)
-    elif authenticated:
+    elif auth_token:
         # default to the caller's PDS — it proxies authenticated app.bsky.*
         # calls to the AppView, so this works for notifications, private
         # feeds, etc., without the caller needing to know AppView routing.

--- a/src/pdsx/mcp/server.py
+++ b/src/pdsx/mcp/server.py
@@ -530,7 +530,12 @@ async def query(
             require_auth=True,
             operation="an authenticated query",
         ) as client:
-            session = client.me
+            # the JWT lives on the client's Session object (client._session),
+            # NOT on client.me — that's the profile view and has no
+            # access_jwt attribute. reading it from `me` made every
+            # authenticated query raise AuthenticationRequired *after* a
+            # successful login, masquerading as "no credentials provided".
+            session = getattr(client, "_session", None)
             access_jwt = (
                 getattr(session, "access_jwt", None) if session is not None else None
             )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -491,9 +491,7 @@ class TestHeaderFallback:
     headers directly when context state is empty."""
 
     @pytest.mark.parametrize("ctx_cls", _CONTEXT_KINDS)
-    async def test_falls_back_to_headers_when_state_empty(
-        self, monkeypatch, ctx_cls
-    ):
+    async def test_falls_back_to_headers_when_state_empty(self, monkeypatch, ctx_cls):
         import fastmcp.server.dependencies as deps
 
         from pdsx.mcp.client import _get_credentials_from_context

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -320,8 +320,21 @@ async def test_query_tool_authenticated_uses_caller_pds_and_jwt(monkeypatch):
     class _FakeSession:
         access_jwt = "jwt-from-session"
 
+    class _FakeProfile:
+        """client.me is a profile view — it has NO access_jwt attribute.
+
+        the original version of this test put the jwt on `me`, which encoded
+        the exact bug it should have caught: the server read the jwt from
+        client.me and every real authenticated query failed after login.
+        the fake must match the real SDK shape: jwt on client._session only.
+        """
+
+        handle = "someone.example"
+        did = "did:plc:someone"
+
     class _FakeClient:
-        me = _FakeSession()
+        me = _FakeProfile()
+        _session = _FakeSession()
 
     @asynccontextmanager
     async def fake_get_client(require_auth=False, operation="", target_repo=None):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -215,16 +215,27 @@ async def test_query_tool_selects_base_url(monkeypatch):
     ]
 
 
-async def test_authenticated_query_rejects_non_allowlisted_nsid():
-    """authenticated=True with an NSID not on the allowlist refuses cleanly,
-    without making any network call or touching credentials. closes the
-    private-data exfiltration surface (e.g., chat.bsky.convo.*) that an
-    untrusted prompt could otherwise reach."""
-    with pytest.raises(ValueError, match="allowlist"):
-        await server.query(
-            nsid="chat.bsky.convo.listConvos",
-            authenticated=True,
-        )
+async def test_non_allowlisted_nsid_never_gets_credentials(monkeypatch):
+    """an NSID off the allowlist is queried publicly — no session, no JWT —
+    even when a caller passes the deprecated authenticated=True flag. this
+    closes the private-data exfiltration surface (e.g., chat.bsky.convo.*)
+    that an untrusted prompt could otherwise reach: the allowlist is the
+    whole auth decision, and no caller-supplied knob can widen it."""
+    captured: list = []
+
+    async def fake_query(nsid, base_url, params=None, auth_token=None):
+        captured.append({"base_url": base_url, "auth_token": auth_token})
+        return {"ok": True}
+
+    def fail_get_client(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("credentials must not be touched for public NSIDs")
+
+    monkeypatch.setattr(server, "_query", fake_query)
+    monkeypatch.setattr(server, "get_atproto_client", fail_get_client)
+
+    await server.query(nsid="chat.bsky.convo.listConvos", authenticated=True)
+
+    assert captured == [{"base_url": server.PUBLIC_APPVIEW, "auth_token": None}]
 
 
 async def test_authenticated_query_allowlist_contains_notifications():
@@ -306,9 +317,9 @@ async def test_unauthenticated_query_accepts_any_nsid_monkeypatched(monkeypatch)
 
 
 async def test_query_tool_authenticated_uses_caller_pds_and_jwt(monkeypatch):
-    """when authenticated=True with no host/repo, route to caller's PDS and
-    attach the session JWT as Bearer — the PDS proxies app.bsky.* auth calls
-    to the AppView."""
+    """an allowlisted NSID with no host/repo routes to the caller's PDS and
+    attaches the session JWT as Bearer automatically — no flag needed. the
+    PDS proxies app.bsky.* auth calls to the AppView."""
     from contextlib import asynccontextmanager
 
     captured: list = []
@@ -351,7 +362,6 @@ async def test_query_tool_authenticated_uses_caller_pds_and_jwt(monkeypatch):
     await server.query(
         nsid="app.bsky.notification.listNotifications",
         params={"limit": 30},
-        authenticated=True,
     )
 
     assert captured == [

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -257,9 +257,7 @@ async def test_query_tool_returns_http_error_as_data(monkeypatch):
         raise httpx.HTTPStatusError("404", request=request, response=response)
 
     monkeypatch.setattr(server, "_query", fake_query)
-    result = await server.query(
-        nsid="com.atproto.sync.listRepos", host="grain.social"
-    )
+    result = await server.query(nsid="com.atproto.sync.listRepos", host="grain.social")
     assert result["error"] == "http_status"
     assert result["status"] == 404
     assert "grain.social" in result["url"]


### PR DESCRIPTION
two commits: `query(authenticated=True)` has failed 100% of the time since it shipped (JWT read from `client.me`, which has no `access_jwt` — every call raised `AuthenticationRequired` *after* a successful login, blaming missing credentials), and the fix exposed that the `authenticated` kwarg itself was a smell: the allowlist already fully determines which NSIDs need the session, so auth is now automatic and the flag is deprecated-and-ignored.

<details>
<summary>commit 1 — the bug (d5a7592)</summary>

- phi's self-trace audit surfaced 22 identical failures on a ~4h schedule going back a month — a 100% failure rate, not an intermittent one
- reproduced against the hosted server and against current main locally
- a credentials spy showed handle/password present and login succeeding — the failure was `getattr(client.me, "access_jwt", None)` returning None; the JWT lives on `client._session` (a `Session` dataclass)
- after the fix, a live local run returned real notifications through the authenticated path
- the existing test never caught it because its fake client put the jwt on `.me` — the fake now matches the real SDK shape

</details>

<details>
<summary>commit 2 — the smell (8ea37aa)</summary>

- the caller-supplied `authenticated` flag was a redundant degree of freedom: the server already fully determines auth need from the NSID (the allowlist), and both allowlisted endpoints are auth-only
- for LLM callers the flag was a knob to guess at, with a misleading failure mode when guessed wrong
- now: allowlisted NSIDs authenticate automatically; everything else is always public — no caller-supplied knob can widen the boundary (regression-tested: a non-allowlisted NSID never touches credentials even with `authenticated=True` passed)
- the kwarg is kept and ignored so existing callers don't fail schema validation; drop it in a later major

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)