### PR TITLE
fix: TypedDict import breaks builds on py<3.12 since pydantic 2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 mcp = [
     "fastmcp>=3.3",
+    "typing-extensions>=4.12",
     "jmespath>=1.0",
 ]
 

--- a/src/pdsx/mcp/_types.py
+++ b/src/pdsx/mcp/_types.py
@@ -1,6 +1,6 @@
 """type definitions for pdsx MCP server."""
 
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 
 class RecordResponse(TypedDict):

--- a/uv.lock
+++ b/uv.lock
@@ -979,6 +979,7 @@ dependencies = [
 mcp = [
     { name = "fastmcp" },
     { name = "jmespath" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -1004,6 +1005,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "typing-extensions", marker = "extra == 'mcp'", specifier = ">=4.12" },
 ]
 provides-extras = ["mcp"]
 


### PR DESCRIPTION
pydantic 2.12 hard-errors on `typing.TypedDict` under python < 3.12. fastmcp cloud's builder resolves fresh deps on a <3.12 python, so every deploy since pydantic 2.12 released has failed at build — production has been pinned to june 7 while the dashboard quietly stacked Failed rows. import from `typing_extensions` instead (explicit dep added); verified import + full test suite on python 3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)