### PR TITLE
fix: fastmcp must be a base dependency for cloud builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "pydantic-settings>=2.7.0",
     "pyyaml>=6.0.3",
     "rich>=13.0.0",
+    "fastmcp>=3.3",
+    "typing-extensions>=4.12",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -969,10 +969,12 @@ name = "pdsx"
 source = { editable = "." }
 dependencies = [
     { name = "atproto" },
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -999,12 +1001,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "atproto", specifier = ">=0.0.63" },
+    { name = "fastmcp", specifier = ">=3.3" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.3" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jmespath", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "typing-extensions", specifier = ">=4.12" },
     { name = "typing-extensions", marker = "extra == 'mcp'", specifier = ">=4.12" },
 ]
 provides-extras = ["mcp"]


### PR DESCRIPTION
fastmcp cloud installs base deps only (no extras) and hard-fails its `find_spec('fastmcp')` check — see the build log on any Failed deployment row. moving `fastmcp` (+ `typing-extensions`, which the mcp module imports directly) into `[project].dependencies`; the `[mcp]` extra stays for compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)