### PR TITLE
fix: resolve the account's own PDS for authenticated writes

### DIFF
--- a/docs/api-reference/pdsx-cli.mdx
+++ b/docs/api-reference/pdsx-cli.mdx
@@ -100,7 +100,7 @@ async_main() -> int
 main entry point.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L593" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L604" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> NoReturn

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -391,6 +391,9 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
         parser.print_help()
         return 1
 
+    # capture before the assignment below, which would itself mark the field set
+    pds_configured = "atproto_pds_url" in settings.model_fields_set
+
     # update pds if provided
     if args.pds:
         settings.atproto_pds_url = args.pds
@@ -423,9 +426,17 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
 
         # create client with or without base_url depending on auth
         if auth_needed:
-            # for authenticated operations, let SDK discover PDS from handle
-            # unless user explicitly provided --pds flag
-            client = AsyncClient(base_url=args.pds) if args.pds else AsyncClient()
+            # writes must go to the account's own PDS: a bare AsyncClient()
+            # defaults to bsky.social, which mints a token the real PDS then
+            # rejects with BadJwtSignature (self-hosted accounts)
+            handle = args.handle or settings.atproto_handle
+            if args.pds or pds_configured:
+                pds_url = settings.atproto_pds_url
+            elif handle:
+                pds_url = await discover_pds(handle)
+            else:
+                pds_url = settings.atproto_pds_url
+            client = AsyncClient(base_url=pds_url)
 
             await login(
                 client,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -190,3 +191,56 @@ class TestDiscoverPds:
 
         with pytest.raises(ValueError, match="could not find PDS"):
             await discover_pds("test.handle")
+
+
+class TestAuthenticatedPdsResolution:
+    """writes must target the account's own PDS, not the bsky.social default.
+
+    regression: a bare AsyncClient() defaults to bsky.social, so writes for
+    self-hosted accounts were signed by the wrong host and rejected with
+    BadJwtSignature.
+    """
+
+    @pytest.mark.asyncio
+    async def test_write_discovers_pds_from_handle(self, mocker) -> None:
+        from pdsx import cli
+
+        mocker.patch.object(cli.settings, "atproto_handle", "zzstoatzz.io")
+        mocker.patch.object(cli.settings, "atproto_password", "pw")
+        mocker.patch.object(cli.settings, "atproto_pds_url", "https://bsky.social")
+        mocker.patch.object(type(cli.settings), "model_fields_set", set())
+
+        discover = mocker.patch.object(
+            cli, "discover_pds", AsyncMock(return_value="https://pds.zzstoatzz.io")
+        )
+        client_cls = mocker.patch.object(cli, "AsyncClient")
+        mocker.patch.object(cli, "login", AsyncMock())
+        mocker.patch.object(cli, "cmd_delete", AsyncMock())
+        mocker.patch.object(
+            sys, "argv", ["pdsx", "rm", "site.standard.document/some-rkey"]
+        )
+
+        assert await cli.async_main() == 0
+        discover.assert_awaited_once_with("zzstoatzz.io")
+        assert client_cls.call_args.kwargs["base_url"] == "https://pds.zzstoatzz.io"
+
+    @pytest.mark.asyncio
+    async def test_explicit_pds_flag_skips_discovery(self, mocker) -> None:
+        from pdsx import cli
+
+        mocker.patch.object(cli.settings, "atproto_handle", "zzstoatzz.io")
+        mocker.patch.object(cli.settings, "atproto_password", "pw")
+
+        discover = mocker.patch.object(cli, "discover_pds", AsyncMock())
+        client_cls = mocker.patch.object(cli, "AsyncClient")
+        mocker.patch.object(cli, "login", AsyncMock())
+        mocker.patch.object(cli, "cmd_delete", AsyncMock())
+        mocker.patch.object(
+            sys,
+            "argv",
+            ["pdsx", "--pds", "https://other.example", "rm", "a.b.c/rkey"],
+        )
+
+        assert await cli.async_main() == 0
+        discover.assert_not_awaited()
+        assert client_cls.call_args.kwargs["base_url"] == "https://other.example"


### PR DESCRIPTION
Writes from self-hosted accounts were going to `bsky.social` instead of the account's own PDS, so they were signed by the wrong host and rejected with `BadJwtSignature`. Reads were fine; only the auth path was broken.

The comment at the call site claimed the SDK would discover the PDS from the handle, but a bare `AsyncClient()` just defaults to `bsky.social` — it discovers nothing.

<details>
<summary>details</summary>

- reads already resolved correctly via `discover_pds`; the authenticated branch never called it
- precedence is now `--pds` → explicit `ATPROTO_PDS_URL` → discovery from the handle → default
- `model_fields_set` is captured *before* the `--pds` assignment mutates `settings`, since that assignment would otherwise make an explicitly configured env value indistinguishable from the default
- two regression tests; the discovery test was verified to fail against the old code
- full suite: 175 passed

Repro before this change:

```
ATPROTO_HANDLE=zzstoatzz.io ATPROTO_PASSWORD=... pdsx whoami
# error: BadJwtSignature   (works with an explicit --pds)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)