### PR TITLE
fix: rm reports missing records instead of claiming success

### DIFF
--- a/docs/api-reference/pdsx-_internal-operations.mdx
+++ b/docs/api-reference/pdsx-_internal-operations.mdx
@@ -10,7 +10,7 @@ atproto record operations.
 
 ## Functions
 
-### `_normalize_query_params` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_normalize_query_params` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L28" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _normalize_query_params(params: dict[str, Any]) -> dict[str, Any]
@@ -23,7 +23,7 @@ XRPC expects lowercase booleans ('true'/'false'); httpx would otherwise
 render Python bools as 'True'/'False'.
 
 
-### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L38" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `query` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L42" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 query(nsid: str, base_url: str, params: dict[str, Any] | None = None, timeout: float = 10.0, auth_token: str | None = None) -> dict[str, Any]
@@ -55,7 +55,7 @@ adds the authority axis without weakening the mutation axis.
 - {'result': &lt;value&gt;}
 
 
-### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L85" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `list_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L89" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 list_records(client: AsyncClient, collection: str, limit: int, repo: str | None = None, cursor: str | None = None) -> models.ComAtprotoRepoListRecords.Response
@@ -75,7 +75,7 @@ list records in a collection.
 - response with records and optional cursor for next page
 
 
-### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L120" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L124" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_record(client: AsyncClient, uri: str, repo: str | None = None) -> models.ComAtprotoRepoGetRecord.Response
@@ -93,7 +93,7 @@ get a specific record.
 - record response
 
 
-### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L163" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `create_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L167" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 create_record(client: AsyncClient, collection: str, record: dict[str, RecordValue], rkey: str | None = None) -> models.ComAtprotoRepoCreateRecord.Response
@@ -112,7 +112,7 @@ create a new record.
 - created record response
 
 
-### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L203" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `update_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 update_record(client: AsyncClient, uri: str, updates: dict[str, RecordValue]) -> models.ComAtprotoRepoPutRecord.Response
@@ -130,7 +130,7 @@ update an existing record.
 - updated record response
 
 
-### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L247" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `delete_record` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L251" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 delete_record(client: AsyncClient, uri: str) -> None
@@ -143,8 +143,11 @@ delete a record.
 - `client`: authenticated atproto client
 - `uri`: record AT-URI (can be shorthand like 'collection/rkey' if authenticated)
 
+**Raises:**
+- `RecordNotFoundError`: if no record exists at the URI
 
-### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L268" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+### `describe_repo` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L283" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 describe_repo(client: AsyncClient, repo: str) -> models.ComAtprotoRepoDescribeRepo.Response
@@ -161,7 +164,7 @@ describe a repo, listing its collections.
 - response with handle, did, didDoc, collections, handleIsCorrect
 
 
-### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L284" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L299" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 upload_blob(client: AsyncClient, file_path: str | Path) -> models.ComAtprotoRepoUploadBlob.Response
@@ -176,4 +179,12 @@ upload a blob (image, video, etc.).
 
 **Returns:**
 - upload response with blob reference
+
+
+## Classes
+
+### `RecordNotFoundError` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/operations.py#L24" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+
+raised when an operation targets a record that does not exist.
 

--- a/src/pdsx/_internal/operations.py
+++ b/src/pdsx/_internal/operations.py
@@ -21,6 +21,10 @@ from pdsx._internal.resolution import URIParts, reject_private_host
 from pdsx._internal.types import RecordValue
 
 
+class RecordNotFoundError(Exception):
+    """raised when an operation targets a record that does not exist."""
+
+
 def _normalize_query_params(params: dict[str, Any]) -> dict[str, Any]:
     """coerce values into XRPC-friendly query params.
 
@@ -253,16 +257,27 @@ async def delete_record(
     Args:
         client: authenticated atproto client
         uri: record AT-URI (can be shorthand like 'collection/rkey' if authenticated)
+
+    Raises:
+        RecordNotFoundError: if no record exists at the URI
     """
     parts = URIParts.from_uri(uri, client.me.did if client.me else None)
+    target = {
+        "repo": parts.repo,
+        "collection": parts.collection,
+        "rkey": parts.rkey,
+    }
 
-    await client.com.atproto.repo.delete_record(
-        {
-            "repo": parts.repo,
-            "collection": parts.collection,
-            "rkey": parts.rkey,
-        }
-    )
+    # deleteRecord is idempotent, so it succeeds just as loudly on a record
+    # that was never there — check first so a no-op can't look like a delete
+    try:
+        await client.com.atproto.repo.get_record(target)
+    except Exception as e:
+        if "RecordNotFound" in str(e) or "Could not locate record" in str(e):
+            raise RecordNotFoundError(f"no record at {uri}") from e
+        raise
+
+    await client.com.atproto.repo.delete_record(target)
 
 
 async def describe_repo(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -8,6 +8,7 @@ import pytest
 from atproto import AsyncClient, models
 
 from pdsx._internal.operations import (
+    RecordNotFoundError,
     create_record,
     delete_record,
     describe_repo,
@@ -175,6 +176,7 @@ class TestDeleteRecord:
 
     async def test_full_uri_format(self, mock_client: AsyncClient) -> None:
         """test delete with full at:// URI format."""
+        mock_client.com.atproto.repo.get_record = AsyncMock()  # type: ignore[attr-defined]
         mock_client.com.atproto.repo.delete_record = AsyncMock()  # type: ignore[attr-defined]
 
         await delete_record(
@@ -190,6 +192,7 @@ class TestDeleteRecord:
 
     async def test_shorthand_uri_format(self, mock_client: AsyncClient) -> None:
         """test delete with shorthand URI format (collection/rkey)."""
+        mock_client.com.atproto.repo.get_record = AsyncMock()  # type: ignore[attr-defined]
         mock_client.com.atproto.repo.delete_record = AsyncMock()  # type: ignore[attr-defined]
 
         await delete_record(
@@ -404,3 +407,37 @@ class TestDescribeRepo:
 
         assert result.handle == "other.bsky.social"
         assert result.collections == ["app.bsky.feed.post"]
+
+
+class TestDeleteRecordMissing:
+    """deleting a nonexistent record must not report success.
+
+    regression: com.atproto.repo.deleteRecord is idempotent, so a delete
+    against the wrong repo (or a bad rkey) returned 200 and printed
+    "deleted" despite removing nothing.
+    """
+
+    async def test_missing_record_raises(self, mock_client: AsyncClient) -> None:
+        mock_client.com.atproto.repo.get_record = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=Exception("RecordNotFound: Could not locate record: at://...")
+        )
+        mock_client.com.atproto.repo.delete_record = AsyncMock()  # type: ignore[attr-defined]
+
+        with pytest.raises(RecordNotFoundError, match="no record at"):
+            await delete_record(mock_client, "app.bsky.feed.post/missing")
+
+        mock_client.com.atproto.repo.delete_record.assert_not_called()
+
+    async def test_unrelated_error_is_not_swallowed(
+        self, mock_client: AsyncClient
+    ) -> None:
+        """an auth/network failure must not be reported as a missing record."""
+        mock_client.com.atproto.repo.get_record = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=Exception("BadJwtSignature")
+        )
+        mock_client.com.atproto.repo.delete_record = AsyncMock()  # type: ignore[attr-defined]
+
+        with pytest.raises(Exception, match="BadJwtSignature"):
+            await delete_record(mock_client, "app.bsky.feed.post/abc123")
+
+        mock_client.com.atproto.repo.delete_record.assert_not_called()


### PR DESCRIPTION
`pdsx rm` printed `✓ deleted` and exited 0 even when it deleted nothing, because `com.atproto.repo.deleteRecord` is idempotent and returns 200 for a record that was never there. A delete aimed at the wrong repo was indistinguishable from a real one.

Found while deleting a record with credentials for the wrong account — the command reported success and the record was still live.

<details>
<summary>details</summary>

- `delete_record` now checks the record exists and raises `RecordNotFoundError` if not; `rm` prints `error: no record at <uri>` and exits 1
- unrelated failures (auth, network) propagate untouched rather than being misreported as a missing record — covered by a test, since collapsing every error into "not found" would just be a quieter version of the same bug
- batch deletes get this via the existing per-URI error handling, so a missing record lands in the failed list instead of the successful one
- the MCP `delete_record` tool inherits it: the raise surfaces as a tool error
- two regression tests; full suite 175 passed

Before / after:

```
$ pdsx rm site.standard.document/does-not-exist
✓ deleted                       # exit 0

$ pdsx rm site.standard.document/does-not-exist
error: no record at site.standard.document/does-not-exist    # exit 1
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)