### PR TITLE
fix: log in against PDSes that don't proxy AppView methods

### DIFF
--- a/docs/api-reference/pdsx-_internal-auth.mdx
+++ b/docs/api-reference/pdsx-_internal-auth.mdx
@@ -10,7 +10,27 @@ authentication utilities for atproto.
 
 ## Functions
 
-### `login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L21" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+_login(client: AsyncClient, handle: str, password: str) -> None
+```
+
+
+log in, tolerating PDSes that do not proxy AppView methods.
+
+``AsyncClient.login`` establishes the session and then populates
+``client.me`` via ``app.bsky.actor.getProfile`` — an AppView method. A PDS
+that doesn't proxy it (zds, for one) answers 404 ``UnknownMethod`` at that
+second step, *after* the session is already set, so a login that actually
+succeeded surfaces as a total failure.
+
+Only the profile lookup is optional, so fall back to the identity the
+session already carries. A non-existent session means createSession itself
+failed (bad credentials), which must still raise.
+
+
+### `login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 login(client: AsyncClient, handle: str | None = None, password: str | None = None) -> bool

--- a/src/pdsx/_internal/auth.py
+++ b/src/pdsx/_internal/auth.py
@@ -6,6 +6,8 @@ import logging
 import sys
 from typing import TYPE_CHECKING
 
+from atproto import models
+from atproto.exceptions import AtProtocolError
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -16,6 +18,30 @@ console = Console()
 
 # silence httpx logs
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
+
+
+async def _login(client: AsyncClient, handle: str, password: str) -> None:
+    """log in, tolerating PDSes that do not proxy AppView methods.
+
+    ``AsyncClient.login`` establishes the session and then populates
+    ``client.me`` via ``app.bsky.actor.getProfile`` — an AppView method. A PDS
+    that doesn't proxy it (zds, for one) answers 404 ``UnknownMethod`` at that
+    second step, *after* the session is already set, so a login that actually
+    succeeded surfaces as a total failure.
+
+    Only the profile lookup is optional, so fall back to the identity the
+    session already carries. A non-existent session means createSession itself
+    failed (bad credentials), which must still raise.
+    """
+    try:
+        await client.login(handle, password)
+    except AtProtocolError:
+        session = getattr(client, "_session", None)
+        if session is None:
+            raise
+        client.me = models.AppBskyActorDefs.ProfileViewDetailed(
+            did=session.did, handle=session.handle
+        )
 
 
 async def login(
@@ -54,9 +80,9 @@ async def login(
             transient=True,
         ) as progress:
             progress.add_task("authenticating...", total=None)
-            await client.login(handle, password)
+            await _login(client, handle, password)
         console.print(f"[dim]✓ authenticated as[/dim] {handle}\n")
     else:
-        await client.login(handle, password)
+        await _login(client, handle, password)
 
     return True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,55 @@
+"""tests for authentication."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from atproto.exceptions import AtProtocolError
+
+from pdsx._internal.auth import _login
+
+
+def _session(did: str = "did:plc:test", handle: str = "zat.dev") -> MagicMock:
+    return MagicMock(did=did, handle=handle)
+
+
+class TestLoginWithoutAppviewProxy:
+    """a PDS that doesn't proxy app.bsky.actor.getProfile must still log in.
+
+    regression: AsyncClient.login sets the session and *then* fetches the
+    profile from the AppView. On a PDS that doesn't proxy that method (zds
+    404s with UnknownMethod), the second step failed and took the whole login
+    with it, breaking every authenticated command against such a host.
+    """
+
+    async def test_profile_failure_falls_back_to_session_identity(self) -> None:
+        client = MagicMock()
+        client.login = AsyncMock(side_effect=AtProtocolError("UnknownMethod"))
+        client._session = _session()
+        client.me = None
+
+        await _login(client, "zat.dev", "pw")
+
+        assert client.me.did == "did:plc:test"
+        assert client.me.handle == "zat.dev"
+
+    async def test_no_session_still_raises(self) -> None:
+        """createSession itself failing (bad password) must not be swallowed."""
+        client = MagicMock()
+        client.login = AsyncMock(side_effect=AtProtocolError("InvalidLogin"))
+        client._session = None
+
+        with pytest.raises(AtProtocolError):
+            await _login(client, "zat.dev", "wrong")
+
+    async def test_normal_login_untouched(self) -> None:
+        """on a PDS that proxies the AppView, nothing changes."""
+        client = MagicMock()
+        client.login = AsyncMock()
+        client.me = "profile-from-appview"
+
+        await _login(client, "zzstoatzz.io", "pw")
+
+        client.login.assert_awaited_once_with("zzstoatzz.io", "pw")
+        assert client.me == "profile-from-appview"


### PR DESCRIPTION
`pdsx` could not authenticate against a PDS that doesn't proxy `app.bsky.actor.getProfile` — every authenticated command failed with a confusing 404 `UnknownMethod`, even though the login had actually succeeded.

`AsyncClient.login` does two things: it establishes the session, then populates `client.me` from the **AppView**. When the second step 404s, the exception takes the whole login with it — including the perfectly good session set moments earlier.

Found while verifying #94 against a live zds instance. `pdsx whoami` against `pds.zat.dev` failed outright while `createSession` succeeded from curl.

<details>
<summary>details</summary>

- only the profile lookup is optional, so the fallback synthesizes `client.me` from the identity the session already carries (`did` + `handle` — the only two required fields on `ProfileViewDetailed`, and the only two pdsx reads)
- no second `createSession`: the session is already set when `get_profile` throws, so the fallback is pure local state
- a **missing** session means `createSession` itself failed (bad credentials) and still raises — verified that a wrong password still exits 1
- 3 regression tests

Verified live:

```
# before — against zds (pds.zat.dev)
$ pdsx whoami
error: Response(success=False, status_code=404, content=XrpcError(error='UnknownMethod', ...))

# after
$ pdsx whoami
zat.dev (did:plc:mkqt76xvfgxuemlwlx6ruc3w)
```

No regression on an AppView-proxying PDS (`pds.zzstoatzz.io` still resolves normally). Full suite 180 passed, `ty` clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)