### PR TITLE
fix: mcp server resolves the account's own PDS and tolerates missing appview

### DIFF
--- a/docs/api-reference/pdsx-_internal-auth.mdx
+++ b/docs/api-reference/pdsx-_internal-auth.mdx
@@ -10,10 +10,10 @@ authentication utilities for atproto.
 
 ## Functions
 
-### `_login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `login_with_session_fallback` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L23" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
-_login(client: AsyncClient, handle: str, password: str) -> None
+login_with_session_fallback(client: AsyncClient, handle: str, password: str) -> None
 ```
 
 
@@ -30,7 +30,7 @@ session already carries. A non-existent session means createSession itself
 failed (bad credentials), which must still raise.
 
 
-### `login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L47" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `login` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/_internal/auth.py#L49" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 login(client: AsyncClient, handle: str | None = None, password: str | None = None) -> bool

--- a/docs/api-reference/pdsx-mcp-client.mdx
+++ b/docs/api-reference/pdsx-mcp-client.mdx
@@ -10,7 +10,7 @@ helper for creating atproto clients with per-request credentials.
 
 ## Functions
 
-### `_maybe_await` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L17" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_maybe_await` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L18" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _maybe_await(value: Any) -> Any
@@ -25,7 +25,7 @@ a different fastmcp than our dependency, so we can't assume either — detect
 at call time instead of relying on the installed version.
 
 
-### `_get_credentials_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L30" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_get_credentials_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L31" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _get_credentials_from_context() -> CredentialsContext
@@ -38,7 +38,7 @@ extract credentials from fastmcp context if available.
 - credentials dict with handle, password, pds_url, repo (any may be None)
 
 
-### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_atproto_client` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L112" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_atproto_client(require_auth: bool = False, operation: str = 'this operation', target_repo: str | None = None) -> AsyncIterator[AsyncClient]
@@ -68,7 +68,7 @@ this enables both:
 - `AuthenticationRequired`: if require_auth=True and no credentials available
 
 
-### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L198" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `get_repo_from_context` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L209" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_repo_from_context() -> str | None
@@ -78,7 +78,7 @@ get_repo_from_context() -> str | None
 get repo override from context if set via x-atproto-repo header.
 
 
-### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `resolve_pds_url` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L218" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 resolve_pds_url() -> str
@@ -97,7 +97,7 @@ to the AppView.
 
 ## Classes
 
-### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L103" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `AuthenticationRequired` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L104" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 raised when an operation requires authentication but none was provided.
@@ -105,7 +105,7 @@ raised when an operation requires authentication but none was provided.
 
 **Methods:**
 
-#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L106" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `__init__` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/mcp/client.py#L107" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 __init__(self, operation: str = 'this operation')

--- a/src/pdsx/_internal/auth.py
+++ b/src/pdsx/_internal/auth.py
@@ -20,7 +20,9 @@ console = Console()
 logging.getLogger("httpx").setLevel(logging.CRITICAL)
 
 
-async def _login(client: AsyncClient, handle: str, password: str) -> None:
+async def login_with_session_fallback(
+    client: AsyncClient, handle: str, password: str
+) -> None:
     """log in, tolerating PDSes that do not proxy AppView methods.
 
     ``AsyncClient.login`` establishes the session and then populates
@@ -80,9 +82,9 @@ async def login(
             transient=True,
         ) as progress:
             progress.add_task("authenticating...", total=None)
-            await _login(client, handle, password)
+            await login_with_session_fallback(client, handle, password)
         console.print(f"[dim]✓ authenticated as[/dim] {handle}\n")
     else:
-        await _login(client, handle, password)
+        await login_with_session_fallback(client, handle, password)
 
     return True

--- a/src/pdsx/mcp/client.py
+++ b/src/pdsx/mcp/client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from atproto import AsyncClient
 
+from pdsx._internal.auth import login_with_session_fallback
 from pdsx.mcp._types import CredentialsContext
 
 logger = logging.getLogger(__name__)
@@ -168,24 +169,34 @@ async def get_atproto_client(
             logger.warning("failed to discover PDS for %s: %s", target_repo, e)
 
     if not pds_url:
-        pds_url = (
-            creds["pds_url"]
-            or os.environ.get("ATPROTO_PDS_URL")
-            or "https://bsky.social"
-        )
+        pds_url = creds["pds_url"] or os.environ.get("ATPROTO_PDS_URL")
+
+    if not pds_url and handle:
+        # authenticated calls must reach the account's OWN pds: bsky.social
+        # mints a token the real host rejects with BadJwtSignature. the CLI
+        # had the same defect; keep the two paths resolving identically.
+        from pdsx._internal.resolution import discover_pds
+
+        try:
+            pds_url = await discover_pds(handle)
+        except ValueError as e:
+            logger.warning("failed to discover PDS for %s: %s", handle, e)
+
+    if not pds_url:
+        pds_url = "https://bsky.social"
 
     client = AsyncClient(pds_url)
 
     if require_auth:
         if handle and password:
             logger.debug("authenticating with provided credentials")
-            await client.login(handle, password)
+            await login_with_session_fallback(client, handle, password)
         else:
             raise AuthenticationRequired(operation)
     elif handle and password and not skip_auth:
         # only authenticate if we're not reading from another user's PDS
         logger.debug("authenticating with provided credentials")
-        await client.login(handle, password)
+        await login_with_session_fallback(client, handle, password)
     else:
         logger.debug("using unauthenticated client for %s", pds_url)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from atproto.exceptions import AtProtocolError
 
-from pdsx._internal.auth import _login
+from pdsx._internal.auth import login_with_session_fallback
 
 
 def _session(did: str = "did:plc:test", handle: str = "zat.dev") -> MagicMock:
@@ -29,7 +29,7 @@ class TestLoginWithoutAppviewProxy:
         client._session = _session()
         client.me = None
 
-        await _login(client, "zat.dev", "pw")
+        await login_with_session_fallback(client, "zat.dev", "pw")
 
         assert client.me.did == "did:plc:test"
         assert client.me.handle == "zat.dev"
@@ -41,7 +41,7 @@ class TestLoginWithoutAppviewProxy:
         client._session = None
 
         with pytest.raises(AtProtocolError):
-            await _login(client, "zat.dev", "wrong")
+            await login_with_session_fallback(client, "zat.dev", "wrong")
 
     async def test_normal_login_untouched(self) -> None:
         """on a PDS that proxies the AppView, nothing changes."""
@@ -49,7 +49,7 @@ class TestLoginWithoutAppviewProxy:
         client.login = AsyncMock()
         client.me = "profile-from-appview"
 
-        await _login(client, "zzstoatzz.io", "pw")
+        await login_with_session_fallback(client, "zzstoatzz.io", "pw")
 
         client.login.assert_awaited_once_with("zzstoatzz.io", "pw")
         assert client.me == "profile-from-appview"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,6 +1,7 @@
 """tests for pdsx MCP server."""
 
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -162,12 +163,41 @@ class TestGetAtprotoClient:
         async with get_atproto_client(target_repo="jay.bsky.team") as client:
             assert "bsky.network" in client._base_url
 
-    async def test_default_pds_when_no_target(self):
-        """uses default bsky.social when no target_repo."""
+    async def test_default_pds_when_no_target(self, monkeypatch):
+        """uses default bsky.social when no target_repo and no credentials.
+
+        the env vars are cleared explicitly: with a handle configured this
+        path now resolves that account's PDS, so leaving a real
+        ATPROTO_HANDLE in the environment used to make this test fail by
+        authenticating for real against bsky.social.
+        """
         from pdsx.mcp.client import get_atproto_client
+
+        for var in ("ATPROTO_HANDLE", "ATPROTO_PASSWORD", "ATPROTO_PDS_URL"):
+            monkeypatch.delenv(var, raising=False)
 
         async with get_atproto_client() as client:
             assert "bsky.social" in client._base_url
+
+    async def test_authenticated_calls_resolve_own_pds(self, monkeypatch, mocker):
+        """auth must target the account's own PDS, not the bsky.social default.
+
+        regression: a self-hosted account got a bsky.social-issued token that
+        its real PDS rejected with BadJwtSignature — the same defect the CLI
+        had.
+        """
+        from pdsx.mcp import client as mcp_client
+
+        monkeypatch.setenv("ATPROTO_HANDLE", "zzstoatzz.io")
+        monkeypatch.setenv("ATPROTO_PASSWORD", "fake-password")
+        monkeypatch.delenv("ATPROTO_PDS_URL", raising=False)
+        login = mocker.patch.object(
+            mcp_client, "login_with_session_fallback", AsyncMock()
+        )
+
+        async with mcp_client.get_atproto_client(require_auth=True) as client:
+            assert "pds.zzstoatzz.io" in client._base_url
+        login.assert_awaited_once()
 
     async def test_skips_auth_when_reading_other_pds(self, monkeypatch):
         """doesn't try to authenticate when reading from another user's PDS."""


### PR DESCRIPTION
The MCP server carried both bugs already fixed for the CLI, so every authenticated MCP operation from a self-hosted account failed with `BadJwtSignature` — and failed outright against zds.

- fell back to `bsky.social` when authenticating instead of discovering the account's PDS (#92's bug)
- called `client.login` directly, which 404s on a PDS that doesn't proxy `app.bsky.actor.getProfile` (#95's bug)

<details>
<summary>empirical before/after</summary>

Against `pds.zzstoatzz.io`, on main before this change:

```
FAILED: UnauthorizedError Response(status_code=401, error='BadJwtSignature')
```

After:

```
base_url: https://pds.zzstoatzz.io/xrpc
me: zzstoatzz.io
authed read ok, records: 2
```

Against zds (`pds.zat.dev`), which previously failed at login entirely:

```
base_url: https://pds.zat.dev/xrpc
me: zat.dev did:plc:mkqt76xvfgxuemlwlx6ruc3w
authed read ok
```
</details>

<details>
<summary>details</summary>

- `_login` becomes the public `login_with_session_fallback`, so the CLI and MCP share one login path instead of drifting apart again. The CLI-facing `login()` wrapper is unchanged — it prints and calls `sys.exit`, which is wrong for a server.
- PDS precedence for authenticated calls: explicit `pds_url` → `ATPROTO_PDS_URL` → discovery from the handle → `bsky.social`. Unauthenticated `target_repo` discovery is untouched.
- Also pins `test_default_pds_when_no_target`, which read real credentials from the environment and made a live authenticated call — it passed or failed depending on the developer's shell. It now clears the vars explicitly.
- 2 tests added/changed; full suite 193 passed, `ty` clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)