### PR TITLE
fix: never print a bare "error:" with no message

### DIFF
--- a/docs/api-reference/pdsx-cli.mdx
+++ b/docs/api-reference/pdsx-cli.mdx
@@ -10,7 +10,21 @@ general-purpose cli for atproto record operations.
 
 ## Functions
 
-### `cmd_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `describe_exception` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L57" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+describe_exception(exc: BaseException) -> str
+```
+
+
+render an exception for the user, never as an empty string.
+
+Several atproto SDK exceptions (InvokeTimeoutError among them) carry no
+message, so interpolating them produced a bare "error:" with nothing after
+it — a failure the user cannot act on or even name.
+
+
+### `cmd_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L73" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_list(client: AsyncClient, collection: str, limit: int, repo: str | None = None, cursor: str | None = None, output_format: OutputFormat | None = None) -> None
@@ -20,7 +34,7 @@ cmd_list(client: AsyncClient, collection: str, limit: int, repo: str | None = No
 list records in a collection.
 
 
-### `cmd_describe` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L84" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_describe` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L100" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_describe(client: AsyncClient, repo: str, output_format: OutputFormat | None = None) -> None
@@ -30,7 +44,7 @@ cmd_describe(client: AsyncClient, repo: str, output_format: OutputFormat | None 
 describe a repo, listing its collections.
 
 
-### `cmd_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L111" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_get(client: AsyncClient, uri: str, output_format: OutputFormat | None = None, repo: str | None = None) -> None
@@ -40,7 +54,7 @@ cmd_get(client: AsyncClient, uri: str, output_format: OutputFormat | None = None
 get a specific record.
 
 
-### `cmd_create` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L107" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_create` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L123" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_create(client: AsyncClient, collection: str, records: list[dict[str, RecordValue]]) -> None
@@ -50,7 +64,7 @@ cmd_create(client: AsyncClient, collection: str, records: list[dict[str, RecordV
 create one or more records.
 
 
-### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L138" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_update` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L154" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordValue]]]) -> None
@@ -60,7 +74,7 @@ cmd_update(client: AsyncClient, updates_list: list[tuple[str, dict[str, RecordVa
 update one or more records.
 
 
-### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L165" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_delete` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L181" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_delete(client: AsyncClient, uris: list[str]) -> None
@@ -70,7 +84,7 @@ cmd_delete(client: AsyncClient, uris: list[str]) -> None
 delete one or more records.
 
 
-### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L191" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_upload_blob` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L207" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_upload_blob(client: AsyncClient, file_path: str) -> None
@@ -80,7 +94,7 @@ cmd_upload_blob(client: AsyncClient, file_path: str) -> None
 upload a blob (image, video, etc.).
 
 
-### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L218" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_whoami` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L234" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_whoami(client: AsyncClient) -> None
@@ -90,13 +104,13 @@ cmd_whoami(client: AsyncClient) -> None
 show authenticated identity.
 
 
-### `_print_unsupported` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `_print_unsupported` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L243" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 _print_unsupported(exc: PermissionedDataUnsupported) -> None
 ```
 
-### `cmd_spaces_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L231" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_spaces_list` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L247" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_spaces_list(client: AsyncClient, pds_url: str) -> int
@@ -110,7 +124,7 @@ reported explicitly and exits 0 rather than failing — but it always says
 why, so "none" is never silently indistinguishable from "can't ask".
 
 
-### `cmd_space_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L270" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_space_records` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L286" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_space_records(client: AsyncClient, pds_url: str) -> int
@@ -120,7 +134,7 @@ cmd_space_records(client: AsyncClient, pds_url: str) -> int
 list records in a permissioned space.
 
 
-### `cmd_space_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L314" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `cmd_space_get` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L330" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 cmd_space_get(client: AsyncClient, pds_url: str) -> int
@@ -130,7 +144,7 @@ cmd_space_get(client: AsyncClient, pds_url: str) -> int
 get one record from a permissioned space.
 
 
-### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L342" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `async_main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L358" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 async_main() -> int
@@ -140,7 +154,7 @@ async_main() -> int
 main entry point.
 
 
-### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L805" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `main` <sup><a href="https://github.com/zzstoatzz/pdsx/blob/main/src/pdsx/cli.py#L821" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 main() -> NoReturn

--- a/src/pdsx/cli.py
+++ b/src/pdsx/cli.py
@@ -54,6 +54,22 @@ from pdsx._internal.resolution import discover_pds  # noqa: E402
 from pdsx._internal.types import RecordValue  # noqa: E402
 
 
+def describe_exception(exc: BaseException) -> str:
+    """render an exception for the user, never as an empty string.
+
+    Several atproto SDK exceptions (InvokeTimeoutError among them) carry no
+    message, so interpolating them produced a bare "error:" with nothing after
+    it — a failure the user cannot act on or even name.
+    """
+    text = str(exc).strip()
+    if text:
+        return text
+    doc = (type(exc).__doc__ or "").strip().splitlines()
+    detail = doc[0].rstrip(".").lower() if doc else ""
+    name = type(exc).__name__
+    return f"{name} ({detail})" if detail else name
+
+
 async def cmd_list(
     client: AsyncClient,
     collection: str,
@@ -659,7 +675,7 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
                 try:
                     parsed = read_records_from_stdin()
                 except ValueError as e:
-                    console.print(f"[red]error:[/red] {e}")
+                    console.print(f"[red]error:[/red] {describe_exception(e)}")
                     return 1
 
                 if not parsed:
@@ -712,7 +728,7 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
                 try:
                     updates_list = read_updates_from_stdin()
                 except ValueError as e:
-                    console.print(f"[red]error:[/red] {e}")
+                    console.print(f"[red]error:[/red] {describe_exception(e)}")
                     return 1
             else:
                 console.print(
@@ -794,7 +810,7 @@ note: -r flag goes BEFORE the command (ls, get, etc.)
         return 0
 
     except Exception as e:
-        console.print(f"[red]error:[/red] {e}")
+        console.print(f"[red]error:[/red] {describe_exception(e)}")
         import os
 
         if os.getenv("DEBUG"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,3 +244,27 @@ class TestAuthenticatedPdsResolution:
         assert await cli.async_main() == 0
         discover.assert_not_awaited()
         assert client_cls.call_args.kwargs["base_url"] == "https://other.example"
+
+
+class TestDescribeException:
+    """a failure the user cannot name is barely better than a silent one.
+
+    regression: atproto SDK exceptions like InvokeTimeoutError carry no
+    message, so `error: {e}` rendered as a bare "error:" with nothing after.
+    """
+
+    def test_empty_message_falls_back_to_type_name(self) -> None:
+        from atproto_client.exceptions import InvokeTimeoutError
+
+        from pdsx.cli import describe_exception
+
+        rendered = describe_exception(InvokeTimeoutError())
+        assert rendered.strip()
+        assert "InvokeTimeoutError" in rendered
+
+    def test_real_message_is_preserved(self) -> None:
+        from pdsx.cli import describe_exception
+
+        assert describe_exception(ValueError("no record at a.b.c/x")) == (
+            "no record at a.b.c/x"
+        )


### PR DESCRIPTION
Some atproto SDK exceptions carry no message — `InvokeTimeoutError` among them — so `error: {e}` rendered as `error:` followed by nothing at all.

Found while capturing validation output for a demo: running several `pdsx` invocations concurrently against a small self-hosted PDS times out during login, and the CLI reported a failure the user could not name, let alone act on.

```
# before
$ pdsx spaces ls -o json
error:                              # exit 1

# after
$ pdsx spaces ls -o json
error: InvokeTimeoutError           # exit 1
```

Falls back to the exception type, plus its docstring summary when it has one. Applied at all three error sites in `cli.py`.

Same principle as #93: a failure you can't name is barely better than a silent one.

2 regression tests; full suite passing, `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)