### PR TITLE
docs: cover the plugin, and correct stale MCP claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ uvx pdsx edit app.bsky.actor.profile/self description='new bio'
 
 ## plugin (claude code / codex)
 
-installs the hosted MCP server and the bundled skills together — no local runtime.
+installs the hosted MCP server **and** the skills together — no local runtime. this
+is the recommended way to use pdsx with an agent: the MCP server gives it the tools,
+the skills teach it the parts that are easy to get wrong.
 
 ```bash
 # claude code
@@ -61,11 +63,56 @@ from a clone, for local development:
 claude --plugin-dir .
 ```
 
-| skill | what it does |
-|-------|-------------|
-| `/pdsx:reading-records` | reading records and blobs from any repo — auth vs none, pagination, identity |
-| `/pdsx:writing-records` | creating, updating, deleting, blob upload, batch JSONL, verifying writes |
-| `/pdsx:experimental-spaces` | permissioned data (`com.atproto.space.*`) — experimental, rarely served |
+### the skills
+
+| skill | reach for it when |
+|-------|-------------------|
+| `/pdsx:reading-records` | inspecting what an account published, pulling records out of a PDS, fetching blob content, or exploring an unfamiliar lexicon |
+| `/pdsx:writing-records` | creating, updating or deleting records, uploading blobs, running batch operations, or checking that a write did what you meant |
+| `/pdsx:experimental-spaces` | working with permissioned data (`com.atproto.space.*`) — experimental, and served by almost no PDS |
+
+they load on demand, so installing all three costs nothing until one is relevant.
+
+### MCP tools or the CLI?
+
+the MCP server covers ordinary record CRUD with structured output. reach for the
+CLI when you need something it doesn't expose:
+
+| you want | use |
+|----------|-----|
+| read / create / update / delete one record | MCP tools |
+| arbitrary read-only XRPC | MCP `query` tool |
+| batch operations over JSONL, with concurrency | CLI — `create`/`update`/`rm` reading stdin |
+| blob upload | CLI — `upload-blob` |
+| permissioned data | CLI — `pdsx spaces …`, no MCP equivalent |
+
+### two things that surprise people
+
+**reads always need a target.** `-r/--repo` is required even when you're
+authenticated — credentials decide what you can see, never where the read goes.
+
+```bash
+pdsx -r you.bsky.social ls app.bsky.feed.post    # your own repo, explicitly
+```
+
+**`ls` returns one page.** default limit is 50 and it does not follow cursors, so
+a collection with 200 records answers with 50 and a cursor on stderr. sort one
+page and you'll draw confident, wrong conclusions about "the latest" of anything.
+
+```bash
+pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq '.[].uri'
+# stderr: next page cursor: 3mrgybvq4w22y
+```
+
+### already using protopack?
+
+[protopack](https://tangled.org/zzstoatzz.io/protopack) bundles the pdsx MCP
+server alongside the Microcosm services. installing both is fine — the server
+registers once, not twice, and you get protopack's skills plus these three.
+
+that pairing is worth having: protopack's `constellation` skill answers "who
+interacted with this record" through the global backlink index, which is far
+better than paginating someone's posts to find replies.
 
 ## MCP server
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,6 +33,7 @@
             "pages": [
               "guides/configure-for-writes",
               "guides/read-repositories",
+              "guides/plugin",
               "guides/mcp-server",
               "guides/batch-operations",
               "guides/crud-safety",

--- a/docs/guides/mcp-server.mdx
+++ b/docs/guides/mcp-server.mdx
@@ -37,7 +37,18 @@ use an [app password](https://bsky.app/settings/app-passwords), not your account
 
 ### custom PDS
 
-if you're running your own PDS (personal data server), add the PDS URL header:
+nothing extra to configure. pdsx resolves your account's PDS from your handle's
+DID document, so a self-hosted account authenticates with the same two headers
+as everyone else.
+
+<Note>
+this used to require an `x-atproto-pds-url` header. it no longer does — authenticated
+calls previously defaulted to `bsky.social`, which mints a token your own PDS rejects
+with `BadJwtSignature`. the PDS is now discovered from your handle.
+</Note>
+
+`x-atproto-pds-url` still exists as an override, for pointing at a host that
+differs from what your DID document names:
 
 ```bash
 claude mcp add-json pdsx '{
@@ -51,9 +62,8 @@ claude mcp add-json pdsx '{
 }'
 ```
 
-<Note>
-when reading public data from other users, pdsx automatically discovers their PDS - you don't need to configure anything. the `x-atproto-pds-url` header is only needed for write operations to your own account on a custom PDS.
-</Note>
+reading public data from another account never needs configuration — pdsx
+discovers their PDS too.
 
 ## local/self-hosted
 
@@ -87,15 +97,23 @@ claude mcp add pdsx --env ATPROTO_HANDLE=your.handle --env ATPROTO_PASSWORD=your
 
 ## available tools
 
-the MCP server exposes five tools for record operations:
+the MCP server exposes eight tools:
 
 | tool | auth required | description |
 |------|--------------|-------------|
 | `list_records` | only without `repo` | list records in a collection |
 | `get_record` | only without `repo` | get a specific record by URI |
+| `describe_repo` | only without `repo` | list the collections a repo holds |
+| `query` | depends on method | issue an arbitrary read-only XRPC query |
 | `create_record` | always | create a new record |
 | `update_record` | always | update an existing record |
 | `delete_record` | always | delete a record |
+| `whoami` | always | show the authenticated identity |
+
+<Note>
+permissioned data (`pdsx spaces …`) is **CLI only** — there are no MCP tools for
+`com.atproto.space.*` while the proposal is still experimental.
+</Note>
 
 ### read operations
 

--- a/docs/guides/plugin.mdx
+++ b/docs/guides/plugin.mdx
@@ -1,0 +1,86 @@
+---
+title: "agent plugin"
+description: "install pdsx into claude code or codex, with skills"
+---
+
+pdsx ships as a plugin for Claude Code and Codex. Installing it registers the
+hosted MCP server **and** a set of skills in one step — the server gives an agent
+the tools, the skills teach it the parts that are easy to get wrong.
+
+Nothing runs locally: the bundled MCP server is hosted.
+
+## install
+
+<CodeGroup>
+
+```bash claude code
+/plugin marketplace add https://github.com/zzstoatzz/pdsx
+/plugin install pdsx
+```
+
+```bash codex
+codex plugin marketplace add https://github.com/zzstoatzz/pdsx
+codex plugin add pdsx@pdsx
+```
+
+```bash from a clone
+claude --plugin-dir .
+```
+
+</CodeGroup>
+
+## what you get
+
+Three skills, loaded on demand — installing all of them costs no context until
+one becomes relevant.
+
+| skill | reach for it when |
+|-------|-------------------|
+| `reading-records` | inspecting what an account published, pulling records out of a PDS, fetching blob content, exploring an unfamiliar lexicon |
+| `writing-records` | creating, updating or deleting records, uploading blobs, batch operations, verifying a write did what you meant |
+| `experimental-spaces` | working with permissioned data (`com.atproto.space.*`) |
+
+Plus the eight MCP tools described in [MCP server](/guides/mcp-server).
+
+## MCP tools or the CLI?
+
+The MCP server covers ordinary record CRUD with structured output. The CLI covers
+everything else.
+
+| you want | use |
+|----------|-----|
+| read / create / update / delete one record | MCP tools |
+| arbitrary read-only XRPC | MCP `query` tool |
+| batch operations over JSONL, with concurrency | CLI reading stdin |
+| blob upload | CLI `upload-blob` |
+| permissioned data | CLI `pdsx spaces …` |
+
+<Note>
+Permissioned data is CLI only. There are no MCP tools for `com.atproto.space.*`
+while the proposal is still experimental.
+</Note>
+
+## authentication
+
+The skills assume credentials come from the environment for CLI use:
+
+```bash
+export ATPROTO_HANDLE=you.bsky.social ATPROTO_PASSWORD=xxxx-xxxx
+```
+
+For the MCP server, credentials are passed as headers — see
+[MCP server](/guides/mcp-server). Self-hosted accounts need no extra
+configuration; the PDS is resolved from your handle.
+
+## using it with protopack
+
+[protopack](https://tangled.org/zzstoatzz.io/protopack) bundles the pdsx MCP
+server alongside the Microcosm services. Installing both is fine — identical
+server configs are deduped, so the tools register once, not twice.
+
+Verified with both plugins loaded: eight pdsx tools total, one copy of each.
+
+The pairing is worth having. protopack's `constellation` skill answers "who
+interacted with this record" through the global backlink index — far better than
+paginating an account's posts to find replies, which is what you'd otherwise
+reach for.


### PR DESCRIPTION
The docs site had **no plugin coverage at all**, and two claims in the MCP guide had gone stale enough to actively mislead.

<details>
<summary>corrections, both verified against the hosted server</summary>

**"the `x-atproto-pds-url` header is only needed for write operations to your own account on a custom PDS"** — no longer true. The PDS is resolved from your handle now, so a self-hosted account needs no extra header. Verified by calling `whoami` on the hosted server with no `x-atproto-pds-url`, for both a self-hosted account and a zds account. The header remains an override for pointing somewhere other than what your DID document names.

**"five tools"** — there are eight. Adds `describe_repo`, `query`, `whoami`, and a note that permissioned data is CLI only with no MCP equivalent.

Also confirmed the hosted server at `pdsx-by-zzstoatzz.fastmcp.app` is current: it authenticates against zds, which was impossible before #95. It tracks main, so no redeploy was needed.
</details>

<details>
<summary>new: guides/plugin</summary>

Install for both clients, what each skill is for, and a table for choosing between MCP tools and the CLI — the CLI-only surface being batch JSONL, blob upload, and `spaces`.

README gains the same guidance plus the two behaviors that actually catch people: reads require `-r` even when authenticated, and `ls` returns a single page.
</details>

<details>
<summary>i had this backwards</summary>

I first wrote that installing pdsx and protopack together registers the MCP server **twice**, and put that warning in both the README and the new guide. Then I loaded both plugins and counted: eight pdsx tools, one copy of each. Identical server configs are deduped.

Both files now say the opposite, which is the true thing — the two compose cleanly, and protopack's `constellation` skill is a genuinely better answer for backlink queries than paginating posts.
</details>

208 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)