### PR TITLE
docs: the documented install silently gives users 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,26 @@ general-purpose cli for atproto record operations
 ## installation
 
 ```bash
-uv add pdsx
+uv add --prerelease=allow pdsx
 # or run directly
-uvx pdsx --help
+uvx --prerelease=allow pdsx --help
 # or from GitHub (latest)
-uvx --from git+https://github.com/zzstoatzz/pdsx pdsx --help
+uvx --prerelease=allow --from git+https://github.com/zzstoatzz/pdsx pdsx --help
 ```
+
+> **`--prerelease=allow` is required.** pdsx depends on `fastmcp==4.0.0a1`, and
+> resolvers skip pre-releases unless asked. Without the flag you don't get an
+> error — you silently get **0.1.5**, the last release published before that
+> pin, missing everything since.
+>
+> To make it stick in a project, put this in your `pyproject.toml`:
+>
+> ```toml
+> [tool.uv]
+> prerelease = "allow"
+> ```
+>
+> This goes away when fastmcp 4.0 ships stable.
 
 ## quick start
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,14 +7,32 @@ description: "get up and running with pdsx in 5 minutes"
 
 ```bash
 # use with uvx (no install)
-uvx pdsx --help
+uvx --prerelease=allow pdsx --help
 
 # or install with uv
-uv add pdsx
+uv add --prerelease=allow pdsx
 
 # or install with pip
-pip install pdsx
+pip install --pre pdsx
 ```
+
+<Warning>
+The pre-release flag is required. pdsx depends on `fastmcp==4.0.0a1`, and
+resolvers skip pre-releases unless asked.
+
+Leaving it off does **not** produce an error — you silently get **0.1.5**, the
+last release published before that pin. Check with `pdsx --version` if something
+seems missing.
+
+To make it persistent in a project:
+
+```toml
+[tool.uv]
+prerelease = "allow"
+```
+
+This requirement goes away when fastmcp 4.0 ships stable.
+</Warning>
 
 ## reading records (no auth)
 

--- a/plugins/pdsx/skills/experimental-spaces/SKILL.md
+++ b/plugins/pdsx/skills/experimental-spaces/SKILL.md
@@ -11,6 +11,10 @@ user-invocable: true
 
 [proposal]: https://github.com/bluesky-social/proposals/tree/main/0016-permissioned-data
 
+`pdsx spaces` needs **0.1.7 or newer**. Installing without
+`--prerelease=allow` silently gives you 0.1.5, which has no `spaces` command at
+all — check with `pdsx --version` if the subcommand is missing.
+
 Permissioned data lives outside the public repo. Records in a *space* are not
 in `listRecords`, do not appear on the firehose, and require a credential to
 read. pdsx exposes the read side:

--- a/plugins/pdsx/skills/reading-records/SKILL.md
+++ b/plugins/pdsx/skills/reading-records/SKILL.md
@@ -6,12 +6,15 @@ user-invocable: true
 
 # reading records
 
+<!-- `--prerelease=allow` is required: pdsx pins fastmcp==4.0.0a1, and without
+the flag a resolver silently installs 0.1.5 instead of erroring. -->
+
 Every read targets a repo. Public repo data needs no credentials — `-r` is
 enough, and works against self-hosted servers because pdsx resolves each
 repo's own PDS from its DID document.
 
 ```bash
-uvx pdsx -r zzstoatzz.io ls app.bsky.feed.post
+uvx --prerelease=allow pdsx -r zzstoatzz.io ls app.bsky.feed.post
 ```
 
 ## `-r` is required for reads, always
@@ -36,7 +39,7 @@ Omit the collection to list the repo's collections. Do this before guessing at
 lexicon names — most repos carry records from apps you haven't heard of.
 
 ```bash
-uvx pdsx -r zzstoatzz.io ls
+uvx --prerelease=allow pdsx -r zzstoatzz.io ls
 ```
 
 ## pagination is not automatic — this is the big one
@@ -51,14 +54,14 @@ last week and simply sits on page two.
 The cursor goes to **stderr**, so `-o json` on stdout stays pipeable:
 
 ```bash
-uvx pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq '.[].uri'
+uvx --prerelease=allow pdsx -r zzstoatzz.io ls app.bsky.feed.post -o json | jq '.[].uri'
 # stderr: next page cursor: 3mrgybvq4w22y
 ```
 
 Follow it explicitly:
 
 ```bash
-uvx pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 100 --cursor 3mrgybvq4w22y
+uvx --prerelease=allow pdsx -r zzstoatzz.io ls app.bsky.feed.post --limit 100 --cursor 3mrgybvq4w22y
 ```
 
 When you need a whole collection, loop until no cursor comes back, or go
@@ -75,10 +78,10 @@ you actually reached the end.** Sorting one page tells you about that page.
 
 ```bash
 # full AT-URI
-uvx pdsx get at://did:plc:xbtmt2zjwlrfegqvch7fboei/app.bsky.feed.post/abc123
+uvx --prerelease=allow pdsx get at://did:plc:xbtmt2zjwlrfegqvch7fboei/app.bsky.feed.post/abc123
 
 # shorthand, with -r supplying the repo
-uvx pdsx -r zzstoatzz.io get app.bsky.actor.profile/self
+uvx --prerelease=allow pdsx -r zzstoatzz.io get app.bsky.actor.profile/self
 ```
 
 Shorthand is `collection/rkey`. Profile records always use rkey `self`.
@@ -96,7 +99,7 @@ own PDS.
 
 ```bash
 # 1. pull the ref out of the record
-CID=$(uvx pdsx -r zzstoatzz.io get app.bsky.actor.profile/self -o json \
+CID=$(uvx --prerelease=allow pdsx -r zzstoatzz.io get app.bsky.actor.profile/self -o json \
       | jq -r '.value.avatar.ref."$link"')
 
 # 2. resolve the repo's DID and its PDS

--- a/plugins/pdsx/skills/writing-records/SKILL.md
+++ b/plugins/pdsx/skills/writing-records/SKILL.md
@@ -11,7 +11,7 @@ Writes always go to **your own repo** — the authenticated account. There is no
 
 ```bash
 export ATPROTO_HANDLE=you.bsky.social ATPROTO_PASSWORD=xxxx-xxxx
-uvx pdsx create app.bsky.feed.post text='hello'
+uvx --prerelease=allow pdsx create app.bsky.feed.post text='hello'
 ```
 
 Use an **app password**, never your account password. Writes reach whatever PDS
@@ -25,7 +25,7 @@ get wrong, and a write aimed at the wrong account is not always obvious
 afterward.
 
 ```bash
-uvx pdsx whoami
+uvx --prerelease=allow pdsx whoami
 # zzstoatzz.io (did:plc:xbtmt2zjwlrfegqvch7fboei)
 ```
 
@@ -53,7 +53,7 @@ singleton records — a profile is always rkey `self`.
 result back. Fields you don't mention survive.
 
 ```bash
-uvx pdsx edit app.bsky.actor.profile/self description='new bio'
+uvx --prerelease=allow pdsx edit app.bsky.actor.profile/self description='new bio'
 # displayName, avatar, banner all still there
 ```
 
@@ -85,7 +85,7 @@ A blob has to exist on the PDS before a record can point at it. Upload returns
 the reference to embed.
 
 ```bash
-uvx pdsx upload-blob avatar.jpg
+uvx --prerelease=allow pdsx upload-blob avatar.jpg
 ```
 
 ```json
@@ -113,24 +113,24 @@ recorded and the run continues; `--fail-fast` stops at the first one.
 ```bash
 # create many
 printf '%s\n' '{"text":"post 1"}' '{"text":"post 2"}' \
-  | uvx pdsx create app.bsky.feed.post
+  | uvx --prerelease=allow pdsx create app.bsky.feed.post
 
 # update many — each line needs a uri
 printf '%s\n' '{"uri":"at://…/abc","text":"fixed"}' \
-  | uvx pdsx update
+  | uvx --prerelease=allow pdsx update
 
 # delete many — plain AT-URIs, one per line
-printf '%s\n' 'at://…/abc' 'at://…/def' | uvx pdsx rm
+printf '%s\n' 'at://…/abc' 'at://…/def' | uvx --prerelease=allow pdsx rm
 ```
 
 This composes with reads. Build the URI list, **look at it**, then pipe:
 
 ```bash
-uvx pdsx -r you.bsky.social ls app.bsky.feed.post -o json \
+uvx --prerelease=allow pdsx -r you.bsky.social ls app.bsky.feed.post -o json \
   | jq -r '.[] | select(.value.text | test("^test ")) | .uri' > doomed.txt
 
 wc -l doomed.txt && head doomed.txt      # confirm the set before acting
-uvx pdsx rm < doomed.txt
+uvx --prerelease=allow pdsx rm < doomed.txt
 ```
 
 Never pipe a filter straight into `rm`. The list is cheap to inspect and the
@@ -146,15 +146,15 @@ useless to every consumer.
 Verify by reading back rather than trusting the write:
 
 ```bash
-uvx pdsx create app.bsky.feed.post text='hello'      # note the returned uri
-uvx pdsx -r you.bsky.social get app.bsky.feed.post/<rkey> -o json
+uvx --prerelease=allow pdsx create app.bsky.feed.post text='hello'      # note the returned uri
+uvx --prerelease=allow pdsx -r you.bsky.social get app.bsky.feed.post/<rkey> -o json
 ```
 
 Compare against a record that already works — the strongest check available:
 
 ```bash
 # see how a real record of this type is shaped before writing your own
-uvx pdsx -r someone.bsky.social ls app.bsky.feed.post --limit 1 -o json
+uvx --prerelease=allow pdsx -r someone.bsky.social ls app.bsky.feed.post --limit 1 -o json
 ```
 
 Shapes that are easy to get wrong:


### PR DESCRIPTION
`uvx pdsx` and `uv add pdsx` — the two install commands in the README — resolve to **0.1.5**, not the current release. No error, no warning.

pdsx pins `fastmcp==4.0.0a1`, and resolvers skip pre-releases unless asked. Rather than failing, they fall back to the newest version that satisfies the constraint: 0.1.5, published before that pin landed in #91.

**Every release since — 0.1.6, 0.1.7, 0.1.8 — has been invisible to anyone following the docs.** Including today's auth fixes.

<details>
<summary>how bad</summary>

```
$ uvx pdsx --version
pdsx 0.1.5                      # silently, no warning

$ uvx --prerelease=allow pdsx --version
pdsx 0.1.8
```

0.1.5 has no `spaces` command at all, so `experimental-spaces` would have failed outright for anyone who installed the documented way:

```
$ uvx pdsx@0.1.5 spaces --help
pdsx: error: argument command: invalid choice: 'spaces'
```
</details>

<details>
<summary>what changed</summary>

`--prerelease=allow` added to every install path — README, quickstart, and all 19 `uvx` invocations across the skills — with the reason stated and the persistent form for projects:

```toml
[tool.uv]
prerelease = "allow"
```

Verified all three routes land on 0.1.8: `uvx --prerelease=allow`, `uv add --prerelease=allow`, and `pip install --pre`.
</details>

<details>
<summary>why not just fix the pin</summary>

The pin is load-bearing in both directions:

- fastmcp has to be in **base** dependencies — #91 moved it there because FastMCP Cloud's builder installs no extras and hard-fails on a missing `fastmcp`. The hosted server depends on this.
- the code genuinely needs **v4**: importing `pdsx.mcp.server` under stable fastmcp 3.4.4 fails with `ModuleNotFoundError: No module named 'mcp_types'`.

So this is a docs fix. The flag becomes unnecessary when fastmcp 4.0 ships stable — worth revisiting then, since a required pre-release flag is a real adoption tax.
</details>

208 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)